### PR TITLE
fix typo, minor but quite important

### DIFF
--- a/docs/upgrade.rst
+++ b/docs/upgrade.rst
@@ -4,7 +4,7 @@ Upgrade guide
 =============
 
 The |version| release of |project| is compatible with the legacy
-django-registration-redux (previously maintained by James Bennett)
+django-registration (previously maintained by James Bennett)
 
 
 Django version requirement


### PR DESCRIPTION
Hola, 

Was browsing through docs, and saw this. I want to override `django-registration` with this package on http://py3readiness.org once it is officially stated (without typo ;) in docs that this is up to date fork)
