### PR TITLE
Fix warning on using ForeignKey vs OneToOneField

### DIFF
--- a/registration/models.py
+++ b/registration/models.py
@@ -186,7 +186,7 @@ class RegistrationProfile(models.Model):
     """
     ACTIVATED = "ALREADY_ACTIVATED"
 
-    user = models.ForeignKey(UserModelString(), unique=True, verbose_name=_('user'))
+    user = models.OneToOneField(UserModelString(), verbose_name=_('user'))
     activation_key = models.CharField(_('activation key'), max_length=40)
 
     objects = RegistrationManager()


### PR DESCRIPTION
Using `django-registration-redux` reveals the following warning:

```
WARNINGS:
registration.RegistrationProfile.user: (fields.W342) Setting unique=True on a ForeignKey has the same effect as using a OneToOneField.
	HINT: ForeignKey(unique=True) is usually better served by a OneToOneField.
```

This pull request simply fixes that issue by replacing the user field with a OneToOneField.