### PR TITLE
Test against Python 3.4 and latest Django releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,14 @@ python:
   - 2.7
   - 3.2
   - 3.3
+  - 3.4
 
 env:
   - DJANGO=Django==1.4.20
   - DJANGO=Django==1.5.12
   - DJANGO=Django==1.6.11
-  - DJANGO=Django==1.7.7
-  - DJANGO=Django==1.8
+  - DJANGO=Django==1.7.8
+  - DJANGO=Django==1.8.1
 
 matrix:
   exclude:
@@ -19,10 +20,12 @@ matrix:
       env: DJANGO=Django==1.4.20
     - python: 3.3
       env: DJANGO=Django==1.4.20
+    - python: 3.4
+      env: DJANGO=Django==1.4.20
     - python: 2.6
-      env: DJANGO=Django==1.7.7
+      env: DJANGO=Django==1.7.8
     - python: 2.6
-      env: DJANGO=Django==1.8
+      env: DJANGO=Django==1.8.1
 
 install:
   - pip install -q $DJANGO


### PR DESCRIPTION
The `setup.py` file indicates that Python 3.4 is supported. I've added that to the travis builds. Also bumped to the latest Django minor versions.