### PR TITLE
Add setting for REGISTRATION_EMAIL_HTML that defaults to True.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,21 +6,32 @@ django-registration-redux changelog
 Version 1.2, 11 May, 2015
 -------------------------------
 
-* BACKWARDS-INCOMPATIBLE CHANGE: An initial migration for Django > 1.7 has been provided.
-  South users will need to configure a null migration with (`SOUTH_MIGRATION_MODULES`).
+* BACKWARDS-INCOMPATIBLE CHANGE: When overriding the
+  `registration/activation_email.txt` template, you must also now override the
+  `registration/activation_email.html` template or set the setting
+  (`REGISTRATION_EMAIL_HTML`) to `False`.
 
-* BACKWARDS-INCOMPATIBLE CHANGE: A `base.html` template is now assumed to exist.
+* BACKWARDS-INCOMPATIBLE CHANGE: An initial migration for Django > 1.7 has been
+  provided. South users will need to configure a null migration with
+  (`SOUTH_MIGRATION_MODULES`).
 
-* Feature: Added settings' options that allows to exlude the default auth urls (`INCLUDE_AUTH_URLS`)
-  and register url (`INCLUDE_REGISTER_URL`).
+* BACKWARDS-INCOMPATIBLE CHANGE: A `base.html` template is now assumed to
+  exist.
 
-* Feature: Added support to dynamically import any chosen registration form using the settings option
-  `REGISTRATION_FORM`.
+* Feature: Added support for disabling HTML emails using the setting option
+  `REGISTRATION_EMAIL_HTML`.
 
-* Enhancement: Make `RegistrationForm` a subclass of Django's `UserCreationForm`
+* Feature: Added settings' options that allows to exlude the default auth urls
+  (`INCLUDE_AUTH_URLS`) and register url (`INCLUDE_REGISTER_URL`).
 
-* Enhancement: Use registration form `save` method to create user instance, whenever form is a subclass of
-  Django's `ModelForm`.
+* Feature: Added support to dynamically import any chosen registration form
+  using the settings option `REGISTRATION_FORM`.
+
+* Enhancement: Make `RegistrationForm` a subclass of Django's
+  `UserCreationForm`
+
+* Enhancement: Use registration form `save` method to create user instance,
+  whenever form is a subclass of Django's `ModelForm`.
 
 
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -146,6 +146,10 @@ your project, and specifying one additional setting:
     string. Falls back to using Django's built-in ``DEFAULT_FROM_EMAIL``
     setting.
 
+``REGISTRATION_EMAIL_HTML``
+    Optional. If this is `False`, registration emails will be send in plain
+    text. If this is `True`, emails will be sent as HTML. Defaults to `True`.
+
 ``REGISTRATION_AUTO_LOGIN``
     Optional. If this is `True`, your users will automatically log in when they
     click on the activation link in their email. Defaults to `False`.
@@ -261,6 +265,10 @@ being used. This template has the following context:
 
 **registration/activation_email.txt**
 
+**IMPORTANT**: If you override this template, you must also override the HTML
+version (below), or disable HTML emails by adding
+``REGISTRATION_EMAIL_HTML = False`` to your settings.py.
+
 Used to generate the text body of the activation email. Should display a
 link the user can click to activate the account. This template has the
 following context:
@@ -287,17 +295,7 @@ following context:
 
 **registration/activation_email.html**
 
-(Optional) If present, this template is used to generate the html body of
-the activation email. Should display the same content as the text version
-of the activation email.
+This template is used to generate the html body of the activation email.
+Should display the same content as the text version of the activation email.
 
 The context available is the same as the text version of the template.
-
-
-To make use of the views from ``django.contrib.auth`` (which are set
-up for you by the default URLconf mentioned above), you will also need
-to create the templates required by those views. Consult `the
-documentation for Django's authentication system
-<http://docs.djangoproject.com/en/dev/topics/auth/>`_ for details
-regarding these templates. Sample templates are provided with this
-project.

--- a/registration/models.py
+++ b/registration/models.py
@@ -295,12 +295,12 @@ class RegistrationProfile(models.Model):
 
         email_message = EmailMultiAlternatives(subject, message_txt, from_email, [self.user.email])
 
-        try:
-            message_html = render_to_string('registration/activation_email.html', ctx_dict)
-        except TemplateDoesNotExist:
-            message_html = None
-
-        if message_html:
-            email_message.attach_alternative(message_html, 'text/html')
+        if getattr(settings, 'REGISTRATION_EMAIL_HTML', True):
+            try:
+                message_html = render_to_string('registration/activation_email.html', ctx_dict)
+            except TemplateDoesNotExist:
+                pass
+            else:
+                email_message.attach_alternative(message_html, 'text/html')
 
         email_message.send()


### PR DESCRIPTION
This addresses the issue raised in https://github.com/macropin/django-registration/issues/50.

Essentially, we just need to document the fact that both templates now need to be overridden. Alternatively, users can add a setting to disable the HTML template.

There is no easy way to determine weather or not a user has overridden one template but not another. It might be possible to inspect the paths of the loaded templates, but that seems like a hack.