### PR TITLE
Lazily import `.sites` models in admin to lessen warning noise

### DIFF
--- a/registration/admin.py
+++ b/registration/admin.py
@@ -1,6 +1,4 @@
 from django.contrib import admin
-from django.contrib.sites.models import RequestSite
-from django.contrib.sites.models import Site
 from django.utils.translation import ugettext_lazy as _
 
 from registration.models import RegistrationProfile
@@ -33,6 +31,8 @@ class RegistrationAdmin(admin.ModelAdmin):
         activated.
 
         """
+        from django.contrib.sites.models import RequestSite
+        from django.contrib.sites.models import Site
         if Site._meta.installed:
             site = Site.objects.get_current()
         else:


### PR DESCRIPTION
When using Django 1.8 with warnings sufficiently enabled, `django.contrib.sites` not in `INSTALLED_APPS` and the admin enabled,

> RemovedInDjango19Warning: Model class django.contrib.sites.models.Site doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.

will occur during app startup (and when running any management command, etc.). The same warning will still occur in the same circumstances when the default registration backend's views are loaded (same two imports), but again, that's not startup time.