### PR TITLE
Close #63. fixed AppRegistryNotReady exception

### DIFF
--- a/registration/forms.py
+++ b/registration/forms.py
@@ -16,8 +16,6 @@ from django.contrib.auth.forms import UserCreationForm
 
 from .users import UserModel, UsernameField
 
-User = UserModel()
-
 
 class RegistrationForm(UserCreationForm):
     """
@@ -36,7 +34,7 @@ class RegistrationForm(UserCreationForm):
     email = forms.EmailField(label=_("E-mail"))
 
     class Meta:
-        model = User
+        model = UserModel()
         fields = (UsernameField(), "email")
 
 

--- a/registration/views.py
+++ b/registration/views.py
@@ -16,7 +16,6 @@ from .compat import import_string
 
 REGISTRATION_FORM_PATH = getattr(settings, 'REGISTRATION_FORM',
                                  'registration.forms.RegistrationForm')
-REGISTRATION_FORM = import_string(REGISTRATION_FORM_PATH)
 
 
 class _RequestPassingFormView(FormView):
@@ -71,7 +70,7 @@ class RegistrationView(_RequestPassingFormView):
 
     """
     disallowed_url = 'registration_disallowed'
-    form_class = REGISTRATION_FORM
+
     http_method_names = ['get', 'post', 'head', 'options', 'trace']
     success_url = None
     template_name = 'registration/registration_form.html'
@@ -86,6 +85,9 @@ class RegistrationView(_RequestPassingFormView):
         if not self.registration_allowed(request):
             return redirect(self.disallowed_url)
         return super(RegistrationView, self).dispatch(request, *args, **kwargs)
+
+    def get_form_class(self, request=None):
+        return import_string(REGISTRATION_FORM_PATH)
 
     def form_valid(self, request, form):
         new_user = self.register(request, form)


### PR DESCRIPTION
used `get_form_class` to lazily instantiate the form on runtime, instead of instantiating it on declaration time as property on the view