### PR TITLE
Removed direct inheritance from `base.html`

### DIFF
--- a/registration/templates/registration/activate.html
+++ b/registration/templates/registration/activate.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "registration/activation_base.html" %}
 {% load i18n %}
 
 {% block content %}

--- a/registration/templates/registration/activation_base.html
+++ b/registration/templates/registration/activation_base.html
@@ -1,0 +1,1 @@
+{% extends "base.html" %}

--- a/registration/templates/registration/activation_complete.html
+++ b/registration/templates/registration/activation_complete.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "registration/activation_base.html" %}
 {% load i18n %}
 
 {% block title %}{% trans "Account Activated" %}{% endblock %}


### PR DESCRIPTION
Removed direct inheritance from `base.html` on activation templates,
instead of direct inheritance, activation templates now extends
`registration/activation_base.html`, and that template extends
`base.html`. That way we can change what template is extended by
activation templates, like it was made for other templates already.