### PR TITLE
Do not install a zipped egg. Fix #103

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
 [pytest]
 DJANGO_SETTINGS_MODULE=test_app.settings_test
 python_files=registration/tests/*.py
+
+[easy_install]
+zip_ok = False


### PR DESCRIPTION
Django (and South) do not support running migrations from eggs since you cannot discover migrations inside an egg. To overcome this, install django-registration-redux an an unzipped package.

For background, see this [south issue](http://south.aeracode.org/ticket/589) and [discussion](https://groups.google.com/forum/#!topic/south-users/Y56DKtTnHT0). This appears to be a common problem in many Django applications.

To test, install django-registation-redux via `python setup.py install` and ensure you can successfully run `python manage.py migrate` on the `test_app`.