### PR TITLE
Disclaim compatibility with django-registration.

### DIFF
--- a/docs/upgrade.rst
+++ b/docs/upgrade.rst
@@ -3,8 +3,8 @@
 Upgrade guide
 =============
 
-The |version| release of |project| is compatible with the legacy
-django-registration (previously maintained by James Bennett)
+The |version| release of |project| is not compatible with the legacy
+django-registration (previously maintained by James Bennett).
 
 
 Django version requirement


### PR DESCRIPTION
Explicitly state that current versions of this package are not
compatible with James Bennett's django-registration package - the
existence of backwards-incompatible changes means that it is not
compatible.