### PR TITLE
Coverage configuration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,5 @@
 [run]
+branch = True
 omit = 
   */migrations/*
   */south_migrations/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,15 @@
+[run]
+omit = 
+  */migrations/*
+  */south_migrations/*
+
+source = registration
+
+[report]
+exclude_lines =
+  # Have to re-enable the standard pragma
+  pragma: no cover
+  
+  # Don't complain if tests don't hit defensive assertion code:
+  raise NotImplementedError
+show_missing = 1


### PR DESCRIPTION
I've added a [`.coveragerc` configuration file](http://coverage.readthedocs.org/en/latest/config.html) that omits the `migrations` and `south_migrations` folders.  They aren't explicitly covered in tests, and shouldn't be included in code coverage. 

I set the branch coverage measurement to True, but coveralls.io doesn't seem to have that feature, yet.  If you wanted to see branch coverage, it'd have to be done locally.

