### PR TITLE
Use Django 1.9 instead of 1.9b1 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,14 @@ python:
 env:
   - DJANGO=Django==1.7.8
   - DJANGO=Django==1.8.2
-  - DJANGO=Django==1.9b1
+  - DJANGO=Django==1.9
 
 matrix:
   exclude:
     - python: 3.5
       env: DJANGO=Django==1.7.8
     - python: 3.3
-      env: DJANGO=Django==1.9b1
+      env: DJANGO=Django==1.9
 
 install:
   - pip install -q $DJANGO


### PR DESCRIPTION
Figured I would start with something small, but necessary.  I am trying to upgrade to Django 1.9, and since the beta is officially over its probably a good idea to feed travis the latest django.  

Builds successfully.  https://travis-ci.org/awbacker/django-registration