### PR TITLE
Fix deprecated class NoArgsCommand class.

### DIFF
--- a/registration/management/commands/cleanupregistration.py
+++ b/registration/management/commands/cleanupregistration.py
@@ -7,13 +7,13 @@ contains the actual logic for determining which accounts are deleted.
 
 """
 
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 
 from ...models import RegistrationProfile
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     help = "Delete expired user registrations from the database"
 
-    def handle_noargs(self, **options):
+    def handle(self, *args, **options):
         RegistrationProfile.objects.delete_expired_users()


### PR DESCRIPTION
Solve the warning RemovedInDjango110Warning: NoArgsCommand class is deprecated and will be removed in Django 1.10. Use BaseCommand instead, which takes no arguments by default.