### PR TITLE
Add alternatives to README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,9 +60,13 @@ functional installation of Django 1.7 or newer.
 Alternatives
 ------------
 
-`django-allauth <http://www.intenct.nl/projects/django-allauth/>`_ is an
-alternative to django-regisitration-redux that provides user registration in
-addition to social authentication and email address management.
+`djangopackages.com <https://www.djangopackages.com/grids/g/registration/>`_
+has a comprehensive comparison of Django packages used for user registration
+and authentication.
+
+For example, `django-allauth <http://www.intenct.nl/projects/django-allauth/>`_
+is an alternative to django-regisitration-redux that provides user registration
+in addition to social authentication and email address management.
 
 License
 -------

--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,13 @@ Note that this application requires Python 2.7/3.4 or later, and a
 functional installation of Django 1.7 or newer.
 
 
+Alternatives
+------------
+
+`django-allauth <http://www.intenct.nl/projects/django-allauth/>`_ is an
+alternative to django-regisitration-redux that provides user registration in
+addition to social authentication and email address management.
+
 License
 -------
 


### PR DESCRIPTION
I believe it's worth adding alternatives to django-registration in the README. django-registration provides a succinct user registration package, but user registration is only one component of self-servicing user management. As you begin to support other forms of authentication, email as username, two-factor, etc, you are required to customize django-registration extensively. Because of this, I have migrated multiple projects to [django-allauth](http://www.intenct.nl/projects/django-allauth/) with success.

Does anyone have any other alternative packages that should be mentioned?