### PR TITLE
Used migrate instead of syncdb

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -167,7 +167,7 @@ Django settings file::
     ACCOUNT_ACTIVATION_DAYS = 7 # One-week activation window; you may, of course, use a different value.
     REGISTRATION_AUTO_LOGIN = True # Automatically log the user in.
 
-Once you've done this, run ``manage.py syncdb`` to install the model
+Once you've done this, run ``python manage.py migrate`` to install the model
 used by the default setup.
 
 


### PR DESCRIPTION
syncdb is deprecated since version 1.7
https://docs.djangoproject.com/en/1.7/ref/django-admin/#syncdb