### PR TITLE
Update copyright. Fix #198.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
-Copyright (c) 2007-2016, James Bennett
+Copyright (c) 2007-2013, James Bennett
+Copyright (c) 2014-2016, Andrew Cutler, Stephen DiCato, and others (see AUTHORS)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Update copyright to reflect current authors and maintainers.
Fix #198.