### PR TITLE
Using a cryptographically secure method to generate activation keys

### DIFF
--- a/registration/models.py
+++ b/registration/models.py
@@ -288,7 +288,7 @@ class RegistrationProfile(models.Model):
         Create a new activation key for the user
         """
         random_string = get_random_string(length=32, allowed_chars=string.printable)
-        self.activation_key = hashlib.sha1(random_string).hexdigest()
+        self.activation_key = hashlib.sha1(random_string.encode('utf-8')).hexdigest()
 
         if save:
             self.save()


### PR DESCRIPTION
I've used Django's `get_random_string` as this uses `random.SystemRandom()`/`os.urandom` and handles the case in which they are not available. You can see the source code here:
https://github.com/django/django/blob/stable/1.8.x/django/utils/crypto.py#L53

As far as I can tell there should be no backwards compatibility issues. I have created a test that should help prove this.

