### PR TITLE
Make Site as optional

### DIFF
--- a/docs/default-backend.rst
+++ b/docs/default-backend.rst
@@ -199,7 +199,7 @@ Additionally, :class:`RegistrationProfile` has a custom manager
    This manager provides several convenience methods for creating and
    working with instances of :class:`RegistrationProfile`:
 
-   .. method:: activate_user(activation_key)
+   .. method:: activate_user(activation_key, site)
 
       Validates ``activation_key`` and, if valid, activates the
       associated account by setting its ``is_active`` field to
@@ -214,6 +214,8 @@ Additionally, :class:`RegistrationProfile` has a custom manager
       :param activation_key: The activation key to use for the
          activation.
       :type activation_key: string, a 40-character SHA1 hexdigest
+      :type site: ``django.contrib.sites.models.Site`` or
+        ``django.contrib.sites.models.RequestSite``
       :rtype: ``User`` or bool
 
    .. method:: delete_expired_users

--- a/registration/admin.py
+++ b/registration/admin.py
@@ -1,8 +1,6 @@
 from django.contrib import admin
 from django.utils.translation import ugettext_lazy as _
-from django.contrib.sites.requests import RequestSite
 from django.contrib.sites.shortcuts import get_current_site
-from django.apps import apps
 
 from .models import RegistrationProfile
 from .users import UsernameField

--- a/registration/admin.py
+++ b/registration/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django.utils.translation import ugettext_lazy as _
 from django.contrib.sites.requests import RequestSite
+from django.contrib.sites.shortcuts import get_current_site
 from django.apps import apps
 
 from .models import RegistrationProfile
@@ -20,8 +21,10 @@ class RegistrationAdmin(admin.ModelAdmin):
         activated.
 
         """
+
+        site = get_current_site(request)
         for profile in queryset:
-            RegistrationProfile.objects.activate_user(profile.activation_key)
+            RegistrationProfile.objects.activate_user(profile.activation_key, site)
     activate_users.short_description = _("Activate users")
 
     def resend_activation_email(self, request, queryset):
@@ -34,11 +37,8 @@ class RegistrationAdmin(admin.ModelAdmin):
         activated.
 
         """
-        if apps.is_installed('django.contrib.sites'):
-            site = apps.get_model('sites', 'Site').objects.get_current()
-        else:
-            site = RequestSite(request)
 
+        site = get_current_site(request)
         for profile in queryset:
             user = profile.user
             RegistrationProfile.objects.resend_activation_mail(user.email, site, request)

--- a/registration/backends/default/views.py
+++ b/registration/backends/default/views.py
@@ -136,8 +136,9 @@ class ActivationView(BaseActivationView):
 
         """
         activation_key = kwargs.get('activation_key', '')
+        site = get_current_site(self.request)
         activated_user = (self.registration_profile.objects
-                          .activate_user(activation_key))
+                          .activate_user(activation_key, site))
         if activated_user:
             signals.user_activated.send(sender=self.__class__,
                                         user=activated_user,

--- a/registration/models.py
+++ b/registration/models.py
@@ -6,7 +6,7 @@ import re
 import string
 
 from django.conf import settings
-from django.contrib.sites.models import Site
+from django.contrib.sites.shortcuts import get_current_site
 from django.core.exceptions import ImproperlyConfigured
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.mail import EmailMultiAlternatives
@@ -422,7 +422,7 @@ class SupervisedRegistrationManager(RegistrationManager):
         """
 
         if not profile.user.is_active and not profile.activated:
-            site = Site.objects.get_current()
+            site = get_current_site()
             self.send_admin_approve_email(profile.user, site)
 
         # do not set ``User.is_active`` as True. This will be set

--- a/registration/models.py
+++ b/registration/models.py
@@ -6,7 +6,6 @@ import re
 import string
 
 from django.conf import settings
-from django.contrib.sites.shortcuts import get_current_site
 from django.core.exceptions import ImproperlyConfigured
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.mail import EmailMultiAlternatives

--- a/registration/models.py
+++ b/registration/models.py
@@ -65,7 +65,7 @@ class RegistrationManager(models.Manager):
 
     """
 
-    def _activate(self, profile, get_profile):
+    def _activate(self, profile, site, get_profile):
         """
         Activate the ``RegistrationProfile`` given as argument.
         User is able to login, as ``is_active`` is set to ``True``
@@ -82,7 +82,7 @@ class RegistrationManager(models.Manager):
         else:
             return user
 
-    def activate_user(self, activation_key, get_profile=False):
+    def activate_user(self, activation_key, site, get_profile=False):
         """
         Validate an activation key and activate the corresponding
         ``User`` if valid.
@@ -125,7 +125,7 @@ class RegistrationManager(models.Manager):
                     return False
 
             if not profile.activation_key_expired():
-                return self._activate(profile, get_profile)
+                return self._activate(profile, site, get_profile)
 
         return False
 
@@ -412,7 +412,7 @@ class RegistrationProfile(models.Model):
 
 class SupervisedRegistrationManager(RegistrationManager):
 
-    def _activate(self, profile, get_profile):
+    def _activate(self, profile, site, get_profile):
         """
         Activate the ``SupervisedRegistrationProfile`` given as argument.
 
@@ -422,7 +422,6 @@ class SupervisedRegistrationManager(RegistrationManager):
         """
 
         if not profile.user.is_active and not profile.activated:
-            site = get_current_site()
             self.send_admin_approve_email(profile.user, site)
 
         # do not set ``User.is_active`` as True. This will be set

--- a/registration/tests/models.py
+++ b/registration/tests/models.py
@@ -241,7 +241,7 @@ class RegistrationModelTests(TestCase):
             site=Site.objects.get_current(), **self.user_info)
         profile = self.registration_profile.objects.get(user=new_user)
         activated = (self.registration_profile.objects
-                     .activate_user(profile.activation_key))
+                     .activate_user(profile.activation_key, Site.objects.get_current()))
 
         self.failUnless(isinstance(activated, UserModel()))
         self.assertEqual(activated.id, new_user.id)
@@ -260,7 +260,8 @@ class RegistrationModelTests(TestCase):
             site=Site.objects.get_current(), **self.user_info)
         profile = self.registration_profile.objects.get(user=new_user)
         activated_profile = (self.registration_profile.objects
-                             .activate_user(profile.activation_key, get_profile=True))
+                             .activate_user(profile.activation_key, Site.objects.get_current(),
+                                            get_profile=True))
 
         self.failUnless(isinstance(activated_profile, self.registration_profile))
         self.assertEqual(activated_profile.id, profile.id)
@@ -284,7 +285,7 @@ class RegistrationModelTests(TestCase):
 
         profile = self.registration_profile.objects.get(user=new_user)
         activated = (self.registration_profile.objects
-                     .activate_user(profile.activation_key))
+                     .activate_user(profile.activation_key, Site.objects.get_current()))
 
         self.failIf(isinstance(activated, UserModel()))
         self.failIf(activated)
@@ -301,7 +302,8 @@ class RegistrationModelTests(TestCase):
         fails.
 
         """
-        self.failIf(self.registration_profile.objects.activate_user('foo'))
+        self.failIf(self.registration_profile.objects.activate_user(
+            'foo', Site.objects.get_current()))
 
     def test_activation_already_activated(self):
         """
@@ -311,11 +313,12 @@ class RegistrationModelTests(TestCase):
         new_user = self.registration_profile.objects.create_inactive_user(
             site=Site.objects.get_current(), **self.user_info)
         profile = self.registration_profile.objects.get(user=new_user)
-        self.registration_profile.objects.activate_user(profile.activation_key)
+        self.registration_profile.objects.activate_user(
+            profile.activation_key, Site.objects.get_current())
 
         profile = self.registration_profile.objects.get(user=new_user)
         self.assertEqual(self.registration_profile.objects.activate_user(
-            profile.activation_key), new_user)
+            profile.activation_key, Site.objects.get_current()), new_user)
 
     def test_activation_deactivated(self):
         """
@@ -324,7 +327,8 @@ class RegistrationModelTests(TestCase):
         new_user = self.registration_profile.objects.create_inactive_user(
             site=Site.objects.get_current(), **self.user_info)
         profile = self.registration_profile.objects.get(user=new_user)
-        self.registration_profile.objects.activate_user(profile.activation_key)
+        self.registration_profile.objects.activate_user(
+            profile.activation_key, Site.objects.get_current())
 
         # Deactivate the new user.
         new_user.is_active = False
@@ -332,7 +336,7 @@ class RegistrationModelTests(TestCase):
 
         # Try to activate again and ensure False is returned.
         failed = self.registration_profile.objects.activate_user(
-            profile.activation_key)
+            profile.activation_key, Site.objects.get_current())
         self.assertFalse(failed)
 
     def test_activation_nonexistent_key(self):
@@ -344,7 +348,8 @@ class RegistrationModelTests(TestCase):
         # Due to the way activation keys are constructed during
         # registration, this will never be a valid key.
         invalid_key = hashlib.sha1(six.b('foo')).hexdigest()
-        self.failIf(self.registration_profile.objects.activate_user(invalid_key))
+        self.failIf(self.registration_profile.objects.activate_user(
+            invalid_key, Site.objects.get_current()))
 
     def test_expired_user_deletion(self):
         """
@@ -460,7 +465,7 @@ class RegistrationModelTests(TestCase):
 
         profile = self.registration_profile.objects.get(user=user)
         activated = (self.registration_profile.objects
-                     .activate_user(profile.activation_key))
+                     .activate_user(profile.activation_key, Site.objects.get_current()))
         self.assertTrue(activated.is_active)
 
         self.assertFalse(self.registration_profile.objects.resend_activation_mail(
@@ -516,7 +521,7 @@ class RegistrationModelTests(TestCase):
 
         self.registration_profile.create_new_activation_key = current_method
         activated = (self.registration_profile.objects
-                     .activate_user(profile.activation_key))
+                     .activate_user(profile.activation_key, Site.objects.get_current()))
 
         self.failUnless(isinstance(activated, UserModel()))
         self.assertEqual(activated.id, new_user.id)
@@ -554,7 +559,7 @@ class SupervisedRegistrationModelTests(RegistrationModelTests):
             site=Site.objects.get_current(), **self.user_info)
         profile = self.registration_profile.objects.get(user=new_user)
         activated = (self.registration_profile.objects
-                     .activate_user(profile.activation_key))
+                     .activate_user(profile.activation_key, Site.objects.get_current()))
 
         self.failUnless(isinstance(activated, UserModel()))
         self.assertEqual(activated.id, new_user.id)
@@ -573,7 +578,8 @@ class SupervisedRegistrationModelTests(RegistrationModelTests):
             site=Site.objects.get_current(), **self.user_info)
         profile = self.registration_profile.objects.get(user=new_user)
         activated_profile = (self.registration_profile.objects
-                             .activate_user(profile.activation_key, get_profile=True))
+                             .activate_user(profile.activation_key, Site.objects.get_current(),
+                                            get_profile=True))
 
         self.failUnless(isinstance(activated_profile, self.registration_profile))
         self.assertEqual(activated_profile.id, profile.id)
@@ -593,7 +599,7 @@ class SupervisedRegistrationModelTests(RegistrationModelTests):
 
         profile = self.registration_profile.objects.get(user=user)
         activated = (self.registration_profile.objects
-                     .activate_user(profile.activation_key))
+                     .activate_user(profile.activation_key, Site.objects.get_current()))
         self.assertFalse(activated.is_active)
 
         self.assertFalse(self.registration_profile.objects.resend_activation_mail(
@@ -752,7 +758,7 @@ class SupervisedRegistrationModelTests(RegistrationModelTests):
             site=Site.objects.get_current(), **self.user_info)
         profile = self.registration_profile.objects.get(user=new_user)
         activated = (self.registration_profile.objects
-                     .activate_user(profile.activation_key))
+                     .activate_user(profile.activation_key, Site.objects.get_current()))
 
         self.failUnless(isinstance(activated, UserModel()))
 
@@ -783,7 +789,7 @@ class SupervisedRegistrationModelTests(RegistrationModelTests):
             site=Site.objects.get_current(), **self.user_info)
         profile = self.registration_profile.objects.get(user=new_user)
         activated = (self.registration_profile.objects
-                     .activate_user(profile.activation_key))
+                     .activate_user(profile.activation_key, Site.objects.get_current()))
 
         self.failUnless(isinstance(activated, UserModel()))
 
@@ -813,11 +819,12 @@ class SupervisedRegistrationModelTests(RegistrationModelTests):
         new_user = self.registration_profile.objects.create_inactive_user(
             site=Site.objects.get_current(), **self.user_info)
         profile = self.registration_profile.objects.get(user=new_user)
-        self.registration_profile.objects.activate_user(profile.activation_key)
+        self.registration_profile.objects.activate_user(
+            profile.activation_key, Site.objects.get_current())
 
         profile = self.registration_profile.objects.get(user=new_user)
         self.assertEqual(self.registration_profile.objects.activate_user(
-            profile.activation_key), False)
+            profile.activation_key, Site.objects.get_current()), False)
 
     def test_activation_key_backwards_compatibility(self):
         """
@@ -846,7 +853,7 @@ class SupervisedRegistrationModelTests(RegistrationModelTests):
 
         self.registration_profile.create_new_activation_key = current_method
         activated = (self.registration_profile.objects
-                     .activate_user(profile.activation_key))
+                     .activate_user(profile.activation_key, Site.objects.get_current()))
 
         self.failUnless(isinstance(activated, UserModel()))
         self.assertEqual(activated.id, new_user.id)


### PR DESCRIPTION
In Django 1.11 and when not use `Site` framework, following error occured.

```
RuntimeError: Model class django.contrib.sites.models.Site doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS.
```

Use a shortcut.