### PR TITLE
Use current database connection's alias for testing. Fixes: #261

### DIFF
--- a/registration/migrations/0003_migrate_activatedstatus.py
+++ b/registration/migrations/0003_migrate_activatedstatus.py
@@ -11,7 +11,8 @@ def migrate_activated_status(apps, schema_editor):
     # Filter the queryset to only fetch already activated profiles.
     # Note, we don't use the string constant `ACTIVATED` because we are using
     # the actual model, not necessarily the Python class which has said attribute.
-    for rp in RegistrationProfile.objects.filter(activation_key='ALREADY_ACTIVATED').iterator():
+    db_alias = schema_editor.connection.alias
+    for rp in RegistrationProfile.objects.using(db_alias).filter(activation_key='ALREADY_ACTIVATED').iterator():
         # Note, it's impossible to get the original activation key, so just
         # leave the ALREADY_ACTIVATED string.
         rp.activated = True


### PR DESCRIPTION
Fixes: #261

In [RunPython](https://docs.djangoproject.com/en/1.11/ref/migration-operations/#django.db.migrations.operations.RunPython), should specify current connection for testing.

You can see a example in above django docs link.

Because use alias in testing. 
May be same problems are occurred when use multiple databases.