### PR TITLE
Add REGISTRATION_ADMINS mail setting for approval

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,9 @@ django-registration-redux changelog
 
 Version 1.8, TBD
 ----------------
+* Feature: Added `REGISTRATION_ADMINS` setting to support different admins (than those in `ADMINS`) in charge of registration.
+Falls back to `ADMINS` in case this is not set
+* Documentation: Added documentation regarding admin approval registration
 
 Version 1.7, 18 July, 2017
 ----------------

--- a/docs/admin-approval-backend.rst
+++ b/docs/admin-approval-backend.rst
@@ -1,0 +1,40 @@
+.. _admin-approval-backend:
+.. module:: registration.backends.admin_approval
+
+The admin approval backend
+==========================
+
+As an alternative to :ref:`the default backend <default-backend>`, and
+an example of writing alternate workflows, |project| bundles
+an approval-needed registration system in
+``registration.backend.admin_approval``. This backend's workflow is similar to
+the default with one extra step of approval from an admin. Specifically the
+steps are the following:
+
+1. A user signs up by filling out a registration form.
+
+2. The user confirms the account by following the link sent to the email
+   address supplied during registration
+
+3. An admin receives an email with a link that will approve the user
+   registration
+
+4. When the admin approves the request, the user receives an email informing
+   them that they can now login
+
+
+Configuration
+-------------
+
+To make use of this backend, simply include the URLConf
+``registration.backends.admin_approval.urls`` at whatever location you choose
+in your URL hierarchy.
+
+This backend makes use of the same settings documented in
+:ref:`the default backend <default-backend>` plus the following settings:
+
+``REGISTRATION_ADMINS``
+    A list with the same structure as the ``ADMINS`` Django setting containing
+    names and emails. Approval emails will be sent to the emails defined here.
+    If this setting is not set (or is empty), emails defined in ``ADMINS``
+    will be used.

--- a/docs/forms.rst
+++ b/docs/forms.rst
@@ -97,7 +97,7 @@ mind, but may also be useful in other situations.
 
 
 Multiple Form Inheritance
-----------------
+-------------------------
 
 Multiple :class:`RegistrationForm` subclasses can be inherited into
 one class.  For instance, if your project requires a terms of service 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,6 +41,7 @@ Contents:
    upgrade
    default-backend
    simple-backend
+   admin-approval-backend
    forms
    views
    signals

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -304,3 +304,104 @@ This template is used to generate the html body of the activation email.
 Should display the same content as the text version of the activation email.
 
 The context available is the same as the text version of the template.
+
+
+**registration/admin_approve_email_subject.txt**
+
+Used to generate the subject line of the approval email sent to the admin.
+Because the subject line of an email must be a single line of text, any output
+from this template will be forcibly condensed to a single line before
+being used. This template has the following context:
+
+``site``
+    An object representing the site on which the user registered;
+    depending on whether ``django.contrib.sites`` is installed, this
+    may be an instance of either ``django.contrib.sites.models.Site``
+    (if the sites application is installed) or
+    ``django.contrib.sites.models.RequestSite`` (if not). Consult `the
+    documentation for the Django sites framework
+    <http://docs.djangoproject.com/en/dev/ref/contrib/sites/>`_ for
+    details regarding these objects' interfaces.
+
+**registration/admin_approve_email.txt**
+
+**IMPORTANT**: If you override this template, you must also override the HTML
+version (below), or disable HTML emails by adding
+``REGISTRATION_EMAIL_HTML = False`` to your settings.py.
+
+Used to generate the text body of the approval email sent to the admin.
+Should display a link the user can click to activate the account.
+This template has the following context:
+
+``user``
+    The username of the user that requests approval for the new account.
+
+``site``
+    An object representing the site on which the user registered;
+    depending on whether ``django.contrib.sites`` is installed, this
+    may be an instance of either ``django.contrib.sites.models.Site``
+    (if the sites application is installed) or
+    ``django.contrib.sites.models.RequestSite`` (if not). Consult `the
+    documentation for the Django sites framework
+    <http://docs.djangoproject.com/en/dev/ref/contrib/sites/>`_ for
+    details regarding these objects' interfaces.
+
+**registration/admin_approve_email.html**
+
+This template is used to generate the html body of the approval email sent to
+the admin.
+Should display the same content as the text version of the approval email.
+
+The context available is the same as the text version of the template.
+
+**registration/admin_approve_complete.html**
+
+Used after successful account approval. This template has no context
+variables of its own, and should simply inform the admin that the user
+account is now approved.
+
+**registration/admin_approve_complete_email_subject.txt**
+
+Used to generate the subject line of the admin approval complete email. Because
+the subject line of an email must be a single line of text, any output
+from this template will be forcibly condensed to a single line before
+being used. This template has the following context:
+
+``site``
+    An object representing the site on which the user registered;
+    depending on whether ``django.contrib.sites`` is installed, this
+    may be an instance of either ``django.contrib.sites.models.Site``
+    (if the sites application is installed) or
+    ``django.contrib.sites.requests.RequestSite`` (if not). Consult `the
+    documentation for the Django sites framework
+    <http://docs.djangoproject.com/en/dev/ref/contrib/sites/>`_ for
+    details regarding these objects' interfaces.
+
+**registration/admin_approve_complete_email.txt**
+
+**IMPORTANT**: If you override this template, you must also override the HTML
+version (below), or disable HTML emails by adding
+``REGISTRATION_EMAIL_HTML = False`` to your settings.py.
+
+Used after successful account activation.
+This template has the following context:
+
+``site``
+    An object representing the site on which the user registered;
+    depending on whether ``django.contrib.sites`` is installed, this
+    may be an instance of either ``django.contrib.sites.models.Site``
+    (if the sites application is installed) or
+    ``django.contrib.sites.requests.RequestSite`` (if not). Consult `the
+    documentation for the Django sites framework
+    <http://docs.djangoproject.com/en/dev/ref/contrib/sites/>`_ for
+    details regarding these objects' interfaces.
+
+
+**registration/admin_approve_complete_email.html**
+
+This template is used to generate the html body of the approval complete email
+sent to the user.
+Should display the same content as the text version of the approval complete
+email.
+
+The context available is the same as the text version of the template.

--- a/docs/signals.rst
+++ b/docs/signals.rst
@@ -6,7 +6,7 @@ Custom signals used by |project|
 ================================
 
 Much of |project|'s customizability comes through the
-ability to write and use :ref:`registration backends <backend-api>`
+ability to write and use registration backends
 implementing different workflows for user registration. However, there
 are many cases where only a small bit of additional logic needs to be
 injected into the registration process, and writing a custom backend

--- a/registration/tests/models.py
+++ b/registration/tests/models.py
@@ -2,6 +2,7 @@ import datetime
 import hashlib
 import re
 import random
+import warnings
 
 from datetime import timedelta
 
@@ -13,6 +14,7 @@ from django.core import management
 from django.test import override_settings
 from django.test import TestCase
 from django.utils.timezone import now as datetime_now
+from django.core.exceptions import ImproperlyConfigured
 
 from registration.models import RegistrationProfile, SupervisedRegistrationProfile
 from registration.users import UserModel
@@ -40,6 +42,9 @@ class RegistrationModelTests(TestCase):
                                       'REGISTRATION_EMAIL_HTML', None)
         self.old_django_email = getattr(settings,
                                         'DEFAULT_FROM_EMAIL', None)
+        self.old_django_admins = getattr(settings, 'ADMINS', None)
+        self.old_registration_admins = getattr(settings, 'REGISTRATION_ADMINS',
+                                               None)
 
         settings.ACCOUNT_ACTIVATION_DAYS = 7
         settings.REGISTRATION_DEFAULT_FROM_EMAIL = 'registration@email.com'
@@ -51,6 +56,8 @@ class RegistrationModelTests(TestCase):
         settings.REGISTRATION_DEFAULT_FROM_EMAIL = self.old_reg_email
         settings.REGISTRATION_EMAIL_HTML = self.old_email_html
         settings.DEFAULT_FROM_EMAIL = self.old_django_email
+        settings.ADMINS = self.old_django_admins
+        settings.REGISTRATION_ADMINS = self.old_registration_admins
 
     def test_profile_creation(self):
         """
@@ -609,7 +616,7 @@ class SupervisedRegistrationModelTests(RegistrationModelTests):
         # Outbox has one mail, admin approve mail
 
         self.assertEqual(len(mail.outbox), 1)
-        admins_emails = [value[1] for value in settings.ADMINS]
+        admins_emails = [value[1] for value in settings.REGISTRATION_ADMINS]
         for email in mail.outbox[0].to:
             self.assertIn(email, admins_emails)
 
@@ -625,7 +632,7 @@ class SupervisedRegistrationModelTests(RegistrationModelTests):
         self.registration_profile.objects.send_admin_approve_email(
             new_user, Site.objects.get_current())
         self.assertEqual(len(mail.outbox), 1)
-        admins_emails = [value[1] for value in settings.ADMINS]
+        admins_emails = [value[1] for value in settings.REGISTRATION_ADMINS]
         for email in mail.outbox[0].to:
             self.assertIn(email, admins_emails)
 
@@ -861,3 +868,35 @@ class SupervisedRegistrationModelTests(RegistrationModelTests):
 
         profile = self.registration_profile.objects.get(user=new_user)
         self.assertTrue(profile.activated)
+
+    def test_no_admins_registered(self):
+        """
+        Approving a non existent user profile does nothing and returns False
+        """
+        new_user = self.registration_profile.objects.create_inactive_user(
+            site=Site.objects.get_current(), **self.user_info)
+
+        settings.ADMINS = ()
+        settings.REGISTRATION_ADMINS = ()
+        with self.assertRaises(ImproperlyConfigured):
+            self.registration_profile.objects.send_admin_approve_email(
+                new_user, Site.objects.get_current())
+
+    def test_no_registration_admins_registered(self):
+        """
+        Approving a non existent user profile does nothing and returns False
+        """
+        new_user = self.registration_profile.objects.create_inactive_user(
+            site=Site.objects.get_current(), **self.user_info)
+
+        settings.REGISTRATION_ADMINS = ()
+
+        with warnings.catch_warnings(record=True) as _warning:
+            self.registration_profile.objects.send_admin_approve_email(
+                new_user, Site.objects.get_current())
+
+            assertion_error = '''No warning triggered for unregistered
+             REGISTRATION_ADMINS'''
+            self.assertTrue(len(_warning) > 0, assertion_error)
+            self.assertTrue('REGISTRATION_ADMINS' in str(_warning[-1].message),
+                            assertion_error)

--- a/registration/tests/models.py
+++ b/registration/tests/models.py
@@ -46,6 +46,7 @@ class RegistrationModelTests(TestCase):
         self.old_registration_admins = getattr(settings, 'REGISTRATION_ADMINS',
                                                None)
 
+        warnings.simplefilter('always', UserWarning)
         settings.ACCOUNT_ACTIVATION_DAYS = 7
         settings.REGISTRATION_DEFAULT_FROM_EMAIL = 'registration@email.com'
         settings.REGISTRATION_EMAIL_HTML = True

--- a/test_app/settings_test.py
+++ b/test_app/settings_test.py
@@ -54,3 +54,9 @@ ADMINS = (
     ('admin1', 'admin1@mail.server.com'),
     ('admin2', 'admin2@mail.server.com'),
 )
+
+
+REGISTRATION_ADMINS = (
+    ('admin1', 'registration_admin1@mail.server.com'),
+    ('admin2', 'registration_admin2@mail.server.com'),
+)


### PR DESCRIPTION
Checks for REGISTRATION_ADMINS defined in settings to use for the
approval email instead of ADMINS. Triggers warning (about using ADMINS)
if setting is not found