### PR TITLE
Add possible settings for activation emails

### DIFF
--- a/docs/default-backend.rst
+++ b/docs/default-backend.rst
@@ -45,6 +45,15 @@ This backend makes use of the following settings:
 ``REGISTRATION_FORM``
     A string dotted path to the desired registration form.
 
+``ACTIVATION_EMAIL_SUBJECT``
+    A string slashed path to the desired template for the activation email subject.
+    
+``ACTIVATION_EMAIL_BODY``
+    A string slashed path to the desired template for the activation email body.
+    
+``ACTIVATION_EMAIL_HTML``
+    A string slashed path tot the desired template for the activation email html.
+
 By default, this backend uses
 :class:`registration.forms.RegistrationForm` as its form class for
 user registration; this can be overridden by passing the keyword


### PR DESCRIPTION
The django settings file may dictate where registration.models.RegistrationProfile.send_activation_email gets templates from. These are the email templates that are sent to a user when they sign up in order to activate their account, and to make custom emails the template source must be changed.