### PR TITLE
Fixing some deprecation warnings for upcoming versions of Django

### DIFF
--- a/registration/compatibility.py
+++ b/registration/compatibility.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+# vi:expandtab:tabstop=4 shiftwidth=4 textwidth=79
+
+import django
+
+# https://docs.djangoproject.com/en/1.10/releases/1.10/#using-user-is-authenticated-and-user-is-anonymous-as-methods
+
+if django.VERSION < (1, 10):
+
+    def is_authenticated(user_instance):
+        return user_instance.is_authenticated()
+
+else:
+
+    def is_authenticated(user_instance):
+        return user_instance.is_authenticated

--- a/registration/migrations/0004_supervisedregistrationprofile.py
+++ b/registration/migrations/0004_supervisedregistrationprofile.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='SupervisedRegistrationProfile',
             fields=[
-                ('registrationprofile_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='registration.RegistrationProfile')),
+                ('registrationprofile_ptr', models.OneToOneField(parent_link=True, auto_created=True, on_delete=models.CASCADE, primary_key=True, serialize=False, to='registration.RegistrationProfile')),
             ],
             bases=('registration.registrationprofile',),
         ),

--- a/registration/views.py
+++ b/registration/views.py
@@ -11,6 +11,7 @@ from django.utils.decorators import method_decorator
 from django.utils.module_loading import import_string
 from django.views.decorators.debug import sensitive_post_parameters
 
+from registration.compatibility import is_authenticated
 from registration.forms import ResendActivationForm
 
 REGISTRATION_FORM_PATH = getattr(settings, 'REGISTRATION_FORM',
@@ -38,13 +39,13 @@ class RegistrationView(FormView):
 
         """
         if ACCOUNT_AUTHENTICATED_REGISTRATION_REDIRECTS:
-            if self.request.user.is_authenticated():
+            if is_authenticated(self.request.user):
                 if settings.LOGIN_REDIRECT_URL is not None:
                     return redirect(settings.LOGIN_REDIRECT_URL)
                 else:
                     raise Exception("You must set a URL with LOGIN_REDIRECT_URL in settings.py or set ACCOUNT_AUTHENTICATED_REGISTRATION_REDIRECTS=False")
 
-        if self.request.user.is_authenticated():
+        if is_authenticated(self.request.user):
             return redirect(settings.LOGIN_REDIRECT_URL)
         if not self.registration_allowed():
             return redirect(self.disallowed_url)


### PR DESCRIPTION
Attempted to fix some deprecation warnings:

* https://docs.djangoproject.com/en/1.11/ref/models/fields/#foreignkey when a ForeignKey does not set a explicitly set a value for `on_delete`, then a deprecation warning raises, starting from Django 1.11.  `on_delete` will be required in Django 2.0

* https://docs.djangoproject.com/en/1.11/releases/1.10/#using-user-is-authenticated-and-user-is-anonymous-as-methods "...The is_authenticated() and is_anonymous() methods of AbstractBaseUser and AnonymousUser classes are now properties. They will still work as methods until Django 2.0, but all usage in Django now uses attribute access...."