### PR TITLE
Revert "change login url"

### DIFF
--- a/registration/templates/registration/password_reset_complete.html
+++ b/registration/templates/registration/password_reset_complete.html
@@ -6,7 +6,7 @@
 {% block content %}
 <p>
     {% trans "Your password has been reset!" %}
-    {% blocktrans %}You may now <a href="{% url 'login' %}">log in</a>{% endblocktrans %}.
+    {% blocktrans %}You may now <a href="{{ login_url }}">log in</a>{% endblocktrans %}.
 
 </p>
 {% endblock %}


### PR DESCRIPTION
Reverts macropin/django-registration#284

PR caused an error identified in #286. According to the Django source code, [`login_url` should be a valid parameter](https://github.com/django/django/blob/5d9b736fd8e09e273fb5aeeca0da268ecea5f1fd/django/contrib/auth/views.py#L328). @cucy what was the original error you were trying to fix? @pgcd thanks for reporting!