### PR TITLE
Fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
       env: DJANGO=Django==1.11.4
 
 install:
+  - pip install --upgrade pip
   - pip install -r requirements.txt
   - pip install -q $DJANGO
   - python setup.py -q install

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ matrix:
       env: DJANGO=Django==1.11.4
 
 install:
-  - pip install --upgrade pip
   - pip install -r requirements.txt
   - pip install -q $DJANGO
   - python setup.py -q install

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ flake8
 coveralls
 Sphinx
 twine
+pytest>3.2.1
 Django>1.8
 invoke==0.12.2
 docutils==0.12


### PR DESCRIPTION
Travis builds non-deterministically fail for python 3.3 due to different versions of the `pytest` library being installed. We now force this package to be `>3.2.1` for builds to pass. 

@ioparaskev this fixes the issue you were going to look at!