### PR TITLE
Fixed typo

### DIFF
--- a/docs/forms.rst
+++ b/docs/forms.rst
@@ -120,6 +120,6 @@ must be inherited first, like this:
 
 You can also add any customization to the form, to add additional fields for
 example. Once you have built your form you must update the
-``REGISTRATION_FORM_PATH`` reflect the string dotted path to the form you wish
+``REGISTRATION_FORM`` reflect the string dotted path to the form you wish
 to use. For our example in ``settings.py`` you would change
-``REGISTRATION_FORM_PATH = 'myapp.forms.CustomForm'``.
+``REGISTRATION_FORM = 'myapp.forms.CustomForm'``.


### PR DESCRIPTION
You need to set ``REGISTRATION_FORM`` variable in ``settings.py`` instead of ``REGISTRATION_FORM_PATH``, because in ``registration/views.py`` ``REGISTRATION_FORM_PATH`` is determined using ``REGISTRATION_FORM``:

    REGISTRATION_FORM_PATH = getattr(settings, 'REGISTRATION_FORM',
                                 'registration.forms.RegistrationForm')
    REGISTRATION_FORM = import_string(REGISTRATION_FORM_PATH)