### PR TITLE
Test against django 2.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,8 @@ django-registration-redux changelog
 
 Version 2.5, TBD
 ----------------
-
+* Feature: Add support for Django 2.1. -
+`#337 <https://github.com/macropin/django-registration/pull/337>_`
 
 Version 2.4, 11 April, 2018
 ----------------

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -4,4 +4,4 @@ Release notes
 =============
 
 The |version| release of |project| supports Python 2.7, 3.4, 3.5, 3.6 and
-Django 1.11 and 2.0.
+Django 1.11, 2.0, and 2.1.

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.1',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@
 envlist =
     {py27,py34,py35,py36}-django111,
     {py34,py35,py36}-django20,
+    {py35,py36}-django21,
 
 [testenv]
 commands =
@@ -15,6 +16,7 @@ deps =
   -rtest-requirements.txt
   django111: Django>=1.11,<2.0
   django20: Django>=2.0,<2.1
+  django21: Django>=2.1,<2.2
 
 [travis]
 python =
@@ -22,3 +24,5 @@ python =
   3.4: py34
   3.5: py35
   3.6: py36
+# TODO add python 3.7 support when travis adds this.
+# https://github.com/travis-ci/travis-ci/issues/9815


### PR DESCRIPTION
Once travis support for python 3.7 is available we can add that to CI for django 2.1, pending resolution of https://github.com/travis-ci/travis-ci/issues/9815