### PR TITLE
pypi: add source packaging too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,6 @@ release: clean lint test
 	# To check whether the README formats properly.
 	python setup.py check -s --restructuredtext
 	# Create the wheels for Python2 and Python3.
-	python setup.py bdist_wheel --universal
+	python setup.py sdist bdist_wheel --universal
 	# Upload to pypi.
 	twine upload dist/*


### PR DESCRIPTION
The source package is needed when installing packages with the `--no-binary=:all:` parameter (to `pip`).