### PR TITLE
Send email on commit

### DIFF
--- a/registration/models.py
+++ b/registration/models.py
@@ -187,8 +187,12 @@ class RegistrationManager(models.Manager):
             registration_profile = self.create_profile(
                 new_user, **profile_info)
 
-        if send_email:
-            registration_profile.send_activation_email(site, request)
+            # send email only if desired and transaction succeeds
+            if send_email:
+                transaction.on_commit(
+                    lambda: registration_profile.send_activation_email(
+                        site, request)
+                )
 
         return new_user
 

--- a/registration/tests/default_backend.py
+++ b/registration/tests/default_backend.py
@@ -3,7 +3,7 @@ import datetime
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.core import mail
-from django.test import TestCase
+from django.test import TransactionTestCase
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from django.urls import reverse
@@ -16,7 +16,7 @@ from registration.users import UserModel
 
 @override_settings(ROOT_URLCONF='test_app.urls_default',
                    ACCOUNT_ACTIVATION_DAYS=7)
-class DefaultBackendViewTests(TestCase):
+class DefaultBackendViewTests(TransactionTestCase):
     """
     Test the default registration backend.
 

--- a/registration/tests/models.py
+++ b/registration/tests/models.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from django.core import mail
 from django.core import management
 from django.core.exceptions import ImproperlyConfigured
-from django.test import TestCase
+from django.test import TransactionTestCase
 from django.test import override_settings
 from django.utils import six
 from django.utils.timezone import now as datetime_now
@@ -27,7 +27,7 @@ Site = apps.get_model('sites', 'Site')
                    REGISTRATION_DEFAULT_FROM_EMAIL='registration@email.com',
                    REGISTRATION_EMAIL_HTML=True,
                    DEFAULT_FROM_EMAIL='django@email.com')
-class RegistrationModelTests(TestCase):
+class RegistrationModelTests(TransactionTestCase):
     """
     Test the model and manager used in the default backend.
 

--- a/test_app/settings_test.py
+++ b/test_app/settings_test.py
@@ -60,3 +60,5 @@ REGISTRATION_ADMINS = (
     ('admin1', 'registration_admin1@mail.server.com'),
     ('admin2', 'registration_admin2@mail.server.com'),
 )
+
+ACCOUNT_ACTIVATION_DAYS = 7


### PR DESCRIPTION
I propose to use `on_commit` for sending out activation emails.

This could be useful when e.g. sending out activation emails are delegated to a celery task. Potential race condition exists, when a user object has yet not been committed to a db while a task broker already attempts to execute email sending. 
A similar problem is described here: https://dev.to/k4ml/django-fixing-race-condition-when-queuing-with-oncommit-hook-7ae

Since `django-registration` relies on Django 1.11+, we could safely use `on_commit` to avoid such situations, as sugested by the post.

The only caveat is that (some) tests would need to use `TransactionTestCase`. 
All the necessary changes are proposed in this PR.