### PR TITLE
save user and registration profile in one transaction

### DIFF
--- a/registration/backends/default/views.py
+++ b/registration/backends/default/views.py
@@ -88,7 +88,7 @@ class RegistrationView(BaseRegistrationView):
         site = get_current_site(self.request)
 
         if hasattr(form, 'save'):
-            new_user_instance = form.save()
+            new_user_instance = form.save(commit=False)
         else:
             new_user_instance = (UserModel().objects
                                  .create_user(**form.cleaned_data))

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,3 +4,4 @@ isort
 tox-travis
 invoke==0.12.2
 docutils==0.13.1
+mock


### PR DESCRIPTION
Default registration form based on `django.contrib.auth.forms.UserCreationForm` which saves active user to db. This PR prevents it and moves user saving to `registration.models.RegistrationManager.create_inactive_user`.

It is up to the developer to maintain this behavior in case of a custom registering form. Especially when custom form omit the save method since the default `UserModel().objects.create_user` implementation also saves user to db.