### PR TITLE
Make instructions specific to admin-approval

### DIFF
--- a/registration/backends/admin_approval/urls.py
+++ b/registration/backends/admin_approval/urls.py
@@ -1,12 +1,12 @@
 """
 URLconf for registration and activation, using django-registration's
-default backend.
+admin approval backend.
 
 If the default behavior of these views is acceptable to you, simply
 use a line like this in your root URLconf to set up the default URLs
 for registration::
 
-    (r'^accounts/', include('registration.backends.default.urls')),
+    (r'^accounts/', include('registration.backends.admin_approval.urls')),
 
 This will also automatically set up the views in
 ``django.contrib.auth`` at sensible default locations.


### PR DESCRIPTION
The comment block had instructions for the default backend, but this file is for admin-approval.