### PR TITLE
Django 3.0 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - 3.5
   - 3.6
   - 3.7
+  - 3.8
 
 install:
     pip install -r test-requirements.txt

--- a/registration/models.py
+++ b/registration/models.py
@@ -27,7 +27,7 @@ from .users import UserModel
 from .users import UserModelString
 
 # Compatibility decorator removed in Django 3
-if DJANGO_VERSION[0] < 2:
+if DJANGO_VERSION[0] < 3:
     from django.utils.encoding import python_2_unicode_compatible
 else:
     from functools import wraps

--- a/registration/models.py
+++ b/registration/models.py
@@ -30,13 +30,8 @@ from .users import UserModelString
 if DJANGO_VERSION[0] < 3:
     from django.utils.encoding import python_2_unicode_compatible
 else:
-    from functools import wraps
-
-    def python_2_unicode_compatible(f):
-        @wraps(f)
-        def wrapper(*args, **kwargs):
-            return f(*args, **kwargs)
-        return wrapper
+    def python_2_unicode_compatible(c):
+        return c
 
 
 logger = logging.getLogger(__name__)

--- a/registration/models.py
+++ b/registration/models.py
@@ -7,6 +7,7 @@ import re
 import string
 import warnings
 
+from django import VERSION as DJANGO_VERSION
 from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -18,13 +19,25 @@ from django.db import transaction
 from django.template import TemplateDoesNotExist
 from django.template.loader import render_to_string
 from django.utils.crypto import get_random_string
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.module_loading import import_string
 from django.utils.timezone import now as datetime_now
 from django.utils.translation import ugettext_lazy as _
 
 from .users import UserModel
 from .users import UserModelString
+
+# Compatibility decorator removed in Django 3
+if DJANGO_VERSION[0] < 2:
+    from django.utils.encoding import python_2_unicode_compatible
+else:
+    from functools import wraps
+
+    def python_2_unicode_compatible(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            return f(*args, **kwargs)
+        return wrapper
+
 
 logger = logging.getLogger(__name__)
 

--- a/registration/tests/forms.py
+++ b/registration/tests/forms.py
@@ -36,7 +36,7 @@ class RegistrationFormTests(TestCase):
 
         password_didnt_match_error = "The two password fields didn't match."
         if django.VERSION >= (3, 0):
-            password_didnt_match_error = "The two password fields didn’t match."
+            password_didnt_match_error = "The two password fields didn\u2019t match."
 
         invalid_data_dicts = [
             # Non-alphanumeric username.

--- a/registration/tests/forms.py
+++ b/registration/tests/forms.py
@@ -33,6 +33,11 @@ class RegistrationFormTests(TestCase):
             bad_username_error = bad_username_error.replace('numbers,', 'numbers')
         elif django.VERSION < (3, 0) and six.PY2:
             bad_username_error = bad_username_error.replace('letters', 'English letters')
+
+        password_didnt_match_error = "The two password fields didn't match."
+        if django.VERSION >= (3, 0):
+            password_didnt_match_error = "The two password fields didn’t match."
+
         invalid_data_dicts = [
             # Non-alphanumeric username.
             {'data': {'username': 'foo/bar',
@@ -51,7 +56,7 @@ class RegistrationFormTests(TestCase):
                       'email': 'foo@example.com',
                       'password1': 'foo',
                       'password2': 'bar'},
-             'error': ('password2', ["The two password fields didn't match."])},
+             'error': ('password2', [password_didnt_match_error])},
         ]
 
         for invalid_dict in invalid_data_dicts:

--- a/registration/tests/forms.py
+++ b/registration/tests/forms.py
@@ -2,10 +2,12 @@ from __future__ import unicode_literals
 
 import django
 from django.test import TestCase
-from django.utils import six
 
 from registration import forms
 from registration.users import UserModel
+
+if django.VERSION[0] < 3:
+    from django.utils import six
 
 
 class RegistrationFormTests(TestCase):
@@ -29,7 +31,7 @@ class RegistrationFormTests(TestCase):
         )
         if django.VERSION < (1, 10):
             bad_username_error = bad_username_error.replace('numbers,', 'numbers')
-        elif six.PY2:
+        elif django.VERSION < (3, 0) and six.PY2:
             bad_username_error = bad_username_error.replace('letters', 'English letters')
         invalid_data_dicts = [
             # Non-alphanumeric username.

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist =
     py3{4,5,6,7}-django20,
     py3{5,6,7}-django21,
     py3{5,6,7}-django22,
+    py3{6,7,8}-django30,
 
 [testenv]
 commands =
@@ -19,6 +20,7 @@ deps =
   django20: Django>=2.0,<2.1
   django21: Django>=2.1,<2.2
   django22: Django>=2.2a1,<3.0
+  django30: Django>=3.0,<3.1
 
 [travis]
 python =
@@ -27,3 +29,4 @@ python =
   3.5: py35
   3.6: py36
   3.7: py37
+  3.8: py38


### PR DESCRIPTION
Adds a basic no-op wrapper in place of a deprecated decorator from Django 3.0. Updates the `tox` environments to cover Django 3.0 and Python 3.8.

Fixes #371 

This is an alternate approach to that taken in #372