### PR TITLE
travis: remove python 3.4 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 sudo: false
 python:
   - 2.7
-  - 3.4
   - 3.5
   - 3.6
   - 3.7


### PR DESCRIPTION
The current django LTS release (2.2) doesn't support python 3.4. And, python 3.4 is failing here anyways.