### PR TITLE
Moved python_2_unicode_compatible dependency from Django to SIX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - 3.5
   - 3.6
   - 3.7
+  - 3.8
 
 install:
     pip install -r test-requirements.txt

--- a/registration/models.py
+++ b/registration/models.py
@@ -18,7 +18,7 @@ from django.db import transaction
 from django.template import TemplateDoesNotExist
 from django.template.loader import render_to_string
 from django.utils.crypto import get_random_string
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 from django.utils.module_loading import import_string
 from django.utils.timezone import now as datetime_now
 from django.utils.translation import ugettext_lazy as _

--- a/registration/models.py
+++ b/registration/models.py
@@ -7,6 +7,8 @@ import re
 import string
 import warnings
 
+from six import python_2_unicode_compatible
+
 from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -21,7 +23,6 @@ from django.utils.crypto import get_random_string
 from django.utils.module_loading import import_string
 from django.utils.timezone import now as datetime_now
 from django.utils.translation import ugettext_lazy as _
-from six import python_2_unicode_compatible
 
 from .users import UserModel
 from .users import UserModelString

--- a/registration/models.py
+++ b/registration/models.py
@@ -7,8 +7,6 @@ import re
 import string
 import warnings
 
-from six import python_2_unicode_compatible
-
 from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -24,6 +22,7 @@ from django.utils.module_loading import import_string
 from django.utils.timezone import now as datetime_now
 from django.utils.translation import ugettext_lazy as _
 
+from .sixfill import python_2_unicode_compatible
 from .users import UserModel
 from .users import UserModelString
 

--- a/registration/models.py
+++ b/registration/models.py
@@ -18,10 +18,10 @@ from django.db import transaction
 from django.template import TemplateDoesNotExist
 from django.template.loader import render_to_string
 from django.utils.crypto import get_random_string
-from six import python_2_unicode_compatible
 from django.utils.module_loading import import_string
 from django.utils.timezone import now as datetime_now
 from django.utils.translation import ugettext_lazy as _
+from six import python_2_unicode_compatible
 
 from .users import UserModel
 from .users import UserModelString

--- a/registration/sixfill.py
+++ b/registration/sixfill.py
@@ -12,7 +12,7 @@ def get_six():
     return importlib.import_module('six')
 
 
-if sys.version_info == (2,):
+if sys.version_info.major == 2:
     python_2_unicode_compatible = get_six().python_2_unicode_compatible
 else:
     python_2_unicode_compatible = nowrap

--- a/registration/sixfill.py
+++ b/registration/sixfill.py
@@ -1,0 +1,18 @@
+import importlib
+import sys
+
+python_2_unicode_compatible = None
+
+
+def nowrap(f, *args, **kwargs):
+    return f
+
+
+def get_six():
+    return importlib.import_module('six')
+
+
+if sys.version_info == (2,):
+    python_2_unicode_compatible = get_six().python_2_unicode_compatible
+else:
+    python_2_unicode_compatible = nowrap

--- a/registration/tests/forms.py
+++ b/registration/tests/forms.py
@@ -1,8 +1,10 @@
 from __future__ import unicode_literals
 
+import six
+from packaging import version
+
 import django
 from django.test import TestCase
-from django.utils import six
 
 from registration import forms
 from registration.users import UserModel
@@ -51,6 +53,9 @@ class RegistrationFormTests(TestCase):
                       'password2': 'bar'},
              'error': ('password2', ["The two password fields didn't match."])},
         ]
+        if version.parse(django.__version__) >= version.parse("3"):
+            password_mismatch_errors = invalid_data_dicts[2]['error'][1]
+            password_mismatch_errors[0] = password_mismatch_errors[0].replace("\u0027", "\u2019")
 
         for invalid_dict in invalid_data_dicts:
             form = forms.RegistrationForm(data=invalid_dict['data'])

--- a/registration/tests/models.py
+++ b/registration/tests/models.py
@@ -7,6 +7,8 @@ import warnings
 from copy import copy
 from datetime import timedelta
 
+import six
+
 from django.apps import apps
 from django.conf import settings
 from django.core import mail
@@ -14,7 +16,6 @@ from django.core import management
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TransactionTestCase
 from django.test import override_settings
-from django.utils import six
 from django.utils.crypto import get_random_string
 from django.utils.timezone import now as datetime_now
 

--- a/registration/tests/sixfill.py
+++ b/registration/tests/sixfill.py
@@ -36,7 +36,7 @@ class SixDynamicPolyfillTestCase(TestCase):
         Test that enusres `python_2_unicode_compatible` found in six polyfill
         contains the right implementation for this python interpreter
         """
-        if sys.version_info == (2,):
+        if sys.version_info.major == 2:
             self.assertIs(python_2_unicode_compatible, six.python_2_unicode_compatible)
         else:
             self.assertIs(python_2_unicode_compatible, nowrap)

--- a/registration/tests/sixfill.py
+++ b/registration/tests/sixfill.py
@@ -30,6 +30,7 @@ class SixDynamicPolyfillTestCase(TestCase):
             return
         wrapped = nowrap(unwrapped)
         self.assertIs(wrapped, unwrapped)
+        unwrapped()  # hack: ensure the return statement will count as tested
 
     def test_python_2_unicode_compatible_defined_in_polyfill_is_the_right_one(self):
         """

--- a/registration/tests/sixfill.py
+++ b/registration/tests/sixfill.py
@@ -1,0 +1,42 @@
+import sys
+
+import six
+
+from django.test import TestCase
+
+from ..sixfill import get_six
+from ..sixfill import nowrap
+from ..sixfill import python_2_unicode_compatible
+
+
+class SixDynamicPolyfillTestCase(TestCase):
+    def test_python_2_unicode_compatible(self):
+        """
+        Test that enusres `python_2_unicode_compatible` is defined
+        """
+        self.assertIsNotNone(python_2_unicode_compatible)
+
+    def test_get_six(self):
+        """
+        Test that enusres `get_six()` returns the same thing as `import six`
+        """
+        self.assertIs(get_six(), six)
+
+    def test_nowrap_does_not_wrap(self):
+        """
+        Test that enusres `nowrap` will return the unwrapped function
+        """
+        def unwrapped():
+            return
+        wrapped = nowrap(unwrapped)
+        self.assertIs(wrapped, unwrapped)
+
+    def test_python_2_unicode_compatible_defined_in_polyfill_is_the_right_one(self):
+        """
+        Test that enusres `python_2_unicode_compatible` found in six polyfill
+        contains the right implementation for this python interpreter
+        """
+        if sys.version_info == (2,):
+            self.assertIs(python_2_unicode_compatible, six.python_2_unicode_compatible)
+        else:
+            self.assertIs(python_2_unicode_compatible, nowrap)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Sphinx
 twine
 pytest>3.2.1
 Django>1.11
+six

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,3 +6,4 @@ invoke==0.12.2
 docutils==0.13.1
 mock
 pytest-django==3.4.8
+six

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,11 @@
 
 [tox]
 envlist =
-    py{27,34,35,36,37}-django111,
-    py3{4,5,6,7}-django20,
-    py3{5,6,7}-django21,
-    py3{5,6,7}-django22,
+    py{27,34,35,36,37,38}-django111,
+    py3{4,5,6,7,8}-django20,
+    py3{5,6,7,8}-django21,
+    py3{5,6,7,8}-django22,
+    py3{6,7,8}-django30,
 
 [testenv]
 commands =
@@ -19,6 +20,7 @@ deps =
   django20: Django>=2.0,<2.1
   django21: Django>=2.1,<2.2
   django22: Django>=2.2a1,<3.0
+  django30: Django>=3.0,<3.1
 
 [travis]
 python =
@@ -27,3 +29,4 @@ python =
   3.5: py35
   3.6: py36
   3.7: py37
+  3.8: py38


### PR DESCRIPTION
Django 3.0 removed `python_2_unicode_compatible` from `django.utils.encoding`. This causes this django app to break.

What Django did in version 2.2 was [just forwarding the same function defined in `six` package](https://github.com/django/django/blob/stable/2.2.x/django/utils/encoding.py#L21). So, if you replace `django.utils.encoding` by `six` on [models.py#L21](https://github.com/macropin/django-registration/blob/012dbc6de505ed862b66ee507af20b654a8ee4b1/registration/models.py#L21), it'll fix the issue.

You might want to bump the version after accepting this pull request.