### PR TITLE
docs: Fix simple typo, modifiying -> modifying

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -15,7 +15,7 @@ General
     |project| is offered under a three-clause BSD-style
     license; this is `an OSI-approved open-source license
     <http://www.opensource.org/licenses/bsd-license.php>`_, and allows
-    you a large degree of freedom in modifiying and redistributing the
+    you a large degree of freedom in modifying and redistributing the
     code. For the full terms, see the file ``LICENSE`` which came with
     your copy of |project|; if you did not receive a copy of
     this file, you can `view it online


### PR DESCRIPTION
There is a small typo in docs/faq.rst.

Should read `modifying` rather than `modifiying`.

