### PR TITLE
Deprecate ugettext in favour of gettext

### DIFF
--- a/registration/admin.py
+++ b/registration/admin.py
@@ -1,9 +1,9 @@
 from django.contrib import admin
 from django.contrib.sites.shortcuts import get_current_site
-from django.utils.translation import ugettext_lazy as _
 
 from .models import RegistrationProfile
 from .users import UsernameField
+from .utils import _
 
 
 class RegistrationAdmin(admin.ModelAdmin):

--- a/registration/forms.py
+++ b/registration/forms.py
@@ -11,10 +11,11 @@ from __future__ import unicode_literals
 
 from django import forms
 from django.contrib.auth.forms import UserCreationForm
-from django.utils.translation import ugettext_lazy as _
 
 from .users import UserModel
 from .users import UsernameField
+from .utils import _
+
 
 User = UserModel()
 

--- a/registration/forms.py
+++ b/registration/forms.py
@@ -16,7 +16,6 @@ from .users import UserModel
 from .users import UsernameField
 from .utils import _
 
-
 User = UserModel()
 
 

--- a/registration/models.py
+++ b/registration/models.py
@@ -21,10 +21,10 @@ from django.template.loader import render_to_string
 from django.utils.crypto import get_random_string
 from django.utils.module_loading import import_string
 from django.utils.timezone import now as datetime_now
-from django.utils.translation import ugettext_lazy as _
 
 from .users import UserModel
 from .users import UserModelString
+from .utils import _
 
 # Compatibility decorator removed in Django 3
 if DJANGO_VERSION[0] < 3:

--- a/registration/utils.py
+++ b/registration/utils.py
@@ -2,6 +2,6 @@ from django import VERSION as DJANGO_VERSION
 
 
 if DJANGO_VERSION[0] < 3:
-    from django.utils.translation import ugettext_lazy as _
+    from django.utils.translation import ugettext_lazy as _  # noqa
 else:
-    from django.utils.translation import gettext_lazy as _
+    from django.utils.translation import gettext_lazy as _  # noqa

--- a/registration/utils.py
+++ b/registration/utils.py
@@ -1,6 +1,5 @@
 from django import VERSION as DJANGO_VERSION
 
-
 if DJANGO_VERSION[0] < 3:
     from django.utils.translation import ugettext_lazy as _  # noqa
 else:

--- a/registration/utils.py
+++ b/registration/utils.py
@@ -1,0 +1,7 @@
+from django import VERSION as DJANGO_VERSION
+
+
+if DJANGO_VERSION[0] < 3:
+    from django.utils.translation import ugettext_lazy as _
+else:
+    from django.utils.translation import gettext_lazy as _


### PR DESCRIPTION
Since Django 3, `ugettext` throws a deprecated warning and is going to be replaced with `gettext`.
https://docs.djangoproject.com/en/3.0/_modules/django/utils/translation/.