### PR TITLE
Document default URLs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,6 +47,7 @@ Contents:
    admin-approval-backend
    forms
    views
+   urls
    signals
    faq
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -234,6 +234,8 @@ emails, all of these are rendered using a ``RequestContext`` and so will also
 receive any additional variables provided by `context processors
 <http://docs.djangoproject.com/en/dev/ref/templates/api/#id1>`_.
 
+.. _registration/registration_form.html:
+
 **registration/registration_form.html**
 
 Used to show the form users will fill out to register. By default, has
@@ -245,12 +247,16 @@ the following context:
     <http://docs.djangoproject.com/en/dev/topics/forms/>`_ for
     information on how to display this in a template.
 
+.. _registration/registration_complete.html:
+
 **registration/registration_complete.html**
 
 Used after successful completion of the registration form. This
 template has no context variables of its own, and should simply inform
 the user that an email containing account-activation information has
 been sent.
+
+.. _registration/activate.html:
 
 **registration/activate.html**
 
@@ -259,11 +265,15 @@ Used if account activation fails. With the default setup, has the following cont
 ``activation_key``
     The activation key used during the activation attempt.
 
+.. _registration/activation_complete.html:
+
 **registration/activation_complete.html**
 
 Used after successful account activation. This template has no context
 variables of its own, and should simply inform the user that their
 account is now active.
+
+.. _registration/activation_email_subject.txt:
 
 **registration/activation_email_subject.txt**
 
@@ -288,6 +298,8 @@ being used. This template has the following context:
     documentation for the Django sites framework
     <http://docs.djangoproject.com/en/dev/ref/contrib/sites/>`_ for
     details regarding these objects' interfaces.
+
+.. _registration/activation_email.txt:
 
 **registration/activation_email.txt**
 
@@ -319,6 +331,8 @@ following context:
 ``user``
     The new user account
 
+.. _registration/activation_email.html:
+
 **registration/activation_email.html**
 
 This template is used to generate the html body of the activation email.
@@ -326,6 +340,7 @@ Should display the same content as the text version of the activation email.
 
 The context available is the same as the text version of the template.
 
+.. _registration/admin_approve_email_subject.txt:
 
 **registration/admin_approve_email_subject.txt**
 
@@ -343,6 +358,8 @@ being used. This template has the following context:
     documentation for the Django sites framework
     <http://docs.djangoproject.com/en/dev/ref/contrib/sites/>`_ for
     details regarding these objects' interfaces.
+
+.. _registration/admin_approve_email.txt:
 
 **registration/admin_approve_email.txt**
 
@@ -367,6 +384,8 @@ This template has the following context:
     <http://docs.djangoproject.com/en/dev/ref/contrib/sites/>`_ for
     details regarding these objects' interfaces.
 
+.. _registration/admin_approve_email.html:
+
 **registration/admin_approve_email.html**
 
 This template is used to generate the html body of the approval email sent to
@@ -375,11 +394,15 @@ Should display the same content as the text version of the approval email.
 
 The context available is the same as the text version of the template.
 
+.. _registration/admin_approve_complete.html:
+
 **registration/admin_approve_complete.html**
 
 Used after successful account approval. This template has no context
 variables of its own, and should simply inform the admin that the user
 account is now approved.
+
+.. _registration/admin_approve_complete_email_subject.txt:
 
 **registration/admin_approve_complete_email_subject.txt**
 
@@ -397,6 +420,8 @@ being used. This template has the following context:
     documentation for the Django sites framework
     <http://docs.djangoproject.com/en/dev/ref/contrib/sites/>`_ for
     details regarding these objects' interfaces.
+
+.. _registration/admin_approve_complete_email.txt:
 
 **registration/admin_approve_complete_email.txt**
 
@@ -417,6 +442,7 @@ This template has the following context:
     <http://docs.djangoproject.com/en/dev/ref/contrib/sites/>`_ for
     details regarding these objects' interfaces.
 
+.. _registration/admin_approve_complete_email.html:
 
 **registration/admin_approve_complete_email.html**
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -234,9 +234,10 @@ emails, all of these are rendered using a ``RequestContext`` and so will also
 receive any additional variables provided by `context processors
 <http://docs.djangoproject.com/en/dev/ref/templates/api/#id1>`_.
 
-.. _registration/registration_form.html:
+.. _registration_form.html:
 
-**registration/registration_form.html**
+registration/registration_form.html
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Used to show the form users will fill out to register. By default, has
 the following context:
@@ -247,41 +248,46 @@ the following context:
     <http://docs.djangoproject.com/en/dev/topics/forms/>`_ for
     information on how to display this in a template.
 
-.. _registration/registration_complete.html:
+.. _registration_complete.html:
 
-**registration/registration_complete.html**
+registration/registration_complete.html
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Used after successful completion of the registration form. This
 template has no context variables of its own, and should simply inform
 the user that an email containing account-activation information has
 been sent.
 
-.. _registration/registration_closed.html:
+.. _registration_closed.html:
 
-**registration/registration_closed.html**
+registration/registration_closed.html
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Used when new account registration has been closed by an administrator.
 
-.. _registration/activate.html:
+.. _activate.html:
 
-**registration/activate.html**
+registration/activate.html
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Used if account activation fails. With the default setup, has the following context:
 
 ``activation_key``
     The activation key used during the activation attempt.
 
-.. _registration/activation_complete.html:
+.. _activation_complete.html:
 
-**registration/activation_complete.html**
+registration/activation_complete.html
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Used after successful account activation. This template has no context
 variables of its own, and should simply inform the user that their
 account is now active.
 
-.. _registration/resend_activation_complete.html:
+.. _resend_activation_complete.html:
 
-**registration/resend_activation_complete.html**
+registration/resend_activation_complete.html
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Used after form for resending account activation is submitted. By default has
 the following context:
@@ -289,9 +295,10 @@ the following context:
 ``email``
     The email address submitted in the resend activation form.
 
-.. _registration/activation_email_subject.txt:
+.. _activation_email_subject.txt:
 
-**registration/activation_email_subject.txt**
+registration/activation_email_subject.txt
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Used to generate the subject line of the activation email. Because the
 subject line of an email must be a single line of text, any output
@@ -315,9 +322,10 @@ being used. This template has the following context:
     <http://docs.djangoproject.com/en/dev/ref/contrib/sites/>`_ for
     details regarding these objects' interfaces.
 
-.. _registration/activation_email.txt:
+.. _activation_email.txt:
 
-**registration/activation_email.txt**
+registration/activation_email.txt
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **IMPORTANT**: If you override this template, you must also override the HTML
 version (below), or disable HTML emails by adding
@@ -347,18 +355,20 @@ following context:
 ``user``
     The new user account
 
-.. _registration/activation_email.html:
+.. _activation_email.html:
 
-**registration/activation_email.html**
+registration/activation_email.html
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This template is used to generate the html body of the activation email.
 Should display the same content as the text version of the activation email.
 
 The context available is the same as the text version of the template.
 
-.. _registration/admin_approve_email_subject.txt:
+.. _admin_approve_email_subject.txt:
 
-**registration/admin_approve_email_subject.txt**
+registration/admin_approve_email_subject.txt
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Used to generate the subject line of the approval email sent to the admin.
 Because the subject line of an email must be a single line of text, any output
@@ -375,9 +385,10 @@ being used. This template has the following context:
     <http://docs.djangoproject.com/en/dev/ref/contrib/sites/>`_ for
     details regarding these objects' interfaces.
 
-.. _registration/admin_approve_email.txt:
+.. _admin_approve_email.txt:
 
-**registration/admin_approve_email.txt**
+registration/admin_approve_email.txt
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **IMPORTANT**: If you override this template, you must also override the HTML
 version (below), or disable HTML emails by adding
@@ -400,9 +411,10 @@ This template has the following context:
     <http://docs.djangoproject.com/en/dev/ref/contrib/sites/>`_ for
     details regarding these objects' interfaces.
 
-.. _registration/admin_approve_email.html:
+.. _admin_approve_email.html:
 
-**registration/admin_approve_email.html**
+registration/admin_approve_email.html
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This template is used to generate the html body of the approval email sent to
 the admin.
@@ -410,17 +422,19 @@ Should display the same content as the text version of the approval email.
 
 The context available is the same as the text version of the template.
 
-.. _registration/admin_approve_complete.html:
+.. _admin_approve_complete.html:
 
-**registration/admin_approve_complete.html**
+registration/admin_approve_complete.html
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Used after successful account approval. This template has no context
 variables of its own, and should simply inform the admin that the user
 account is now approved.
 
-.. _registration/admin_approve_complete_email_subject.txt:
+.. _admin_approve_complete_email_subject.txt:
 
-**registration/admin_approve_complete_email_subject.txt**
+registration/admin_approve_complete_email_subject.txt
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Used to generate the subject line of the admin approval complete email. Because
 the subject line of an email must be a single line of text, any output
@@ -437,9 +451,10 @@ being used. This template has the following context:
     <http://docs.djangoproject.com/en/dev/ref/contrib/sites/>`_ for
     details regarding these objects' interfaces.
 
-.. _registration/admin_approve_complete_email.txt:
+.. _admin_approve_complete_email.txt:
 
-**registration/admin_approve_complete_email.txt**
+registration/admin_approve_complete_email.txt
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **IMPORTANT**: If you override this template, you must also override the HTML
 version (below), or disable HTML emails by adding
@@ -458,9 +473,10 @@ This template has the following context:
     <http://docs.djangoproject.com/en/dev/ref/contrib/sites/>`_ for
     details regarding these objects' interfaces.
 
-.. _registration/admin_approve_complete_email.html:
+.. _admin_approve_complete_email.html:
 
-**registration/admin_approve_complete_email.html**
+registration/admin_approve_complete_email.html
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This template is used to generate the html body of the approval complete email
 sent to the user.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -256,6 +256,12 @@ template has no context variables of its own, and should simply inform
 the user that an email containing account-activation information has
 been sent.
 
+.. _registration/registration_closed.html:
+
+**registration/registration_closed.html**
+
+Used when new account registration has been closed by an administrator.
+
 .. _registration/activate.html:
 
 **registration/activate.html**
@@ -272,6 +278,16 @@ Used if account activation fails. With the default setup, has the following cont
 Used after successful account activation. This template has no context
 variables of its own, and should simply inform the user that their
 account is now active.
+
+.. _registration/resend_activation_complete.html:
+
+**registration/resend_activation_complete.html**
+
+Used after form for resending account activation is submitted. By default has
+the following context:
+
+``email``
+    The email address submitted in the resend activation form.
 
 .. _registration/activation_email_subject.txt:
 

--- a/docs/urls.rst
+++ b/docs/urls.rst
@@ -4,7 +4,7 @@
 Registration urls
 ==================
 
-If you do not wish to configure all of your own URLs for the various registration views, there are several default definitions that you can include in your `urls.py` file.
+If you do not wish to configure all of your own URLs for the various registration views, there are several default definitions that you can include in your ``urls.py`` file.
 
 There is an URL file for :ref:`each of the default backends <basic-urls>`. These files provide all the URLs that you will need for normal interaction.
 
@@ -46,10 +46,10 @@ These URLs are provided by any of the following:
 
 **register/**
  * View: :py:class:`registration.views.RegistrationView`
- * Template: :ref:`registration_form.html <registration/registration_form.html>`
+ * Template: :ref:`registration_form.html`
 
 **register/closed/**
- * Template: :ref:`registration_closed.html <registration/registration_closed.html>`
+ * Template: :ref:`registration_closed.html`
 
 .. _authentication-urls:
 
@@ -59,18 +59,18 @@ Authentication URLs
 Provided by ``registration.auth_urls``, or any of the above includes.
 
 **activate/complete/**
- * Template: :ref:`activation_complete.html <registration/activation_complete.html>`
+ * Template: :ref:`activation_complete.html`
 
 **activate/resend/**
  * View: :py:class:`registration.views.ResendActivationView`
- * Template: :ref:`resend_activation_complete.html <registration/resend_activation_complete.html>`
+ * Template: :ref:`resend_activation_complete.html`
 
 **activate/{key}/**
  * View: :py:class:`registration.views.ActivationView`
- * Template: :ref:`activate.html <registration/activate.html>`
+ * Template: :ref:`activate.html`
 
 **register/complete/**
- * Template: :ref:`registration_complete.html <registration/registration_complete.html>`
+ * Template: :ref:`registration_complete.html`
 
 Admin approval backend
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/urls.rst
+++ b/docs/urls.rst
@@ -6,6 +6,12 @@ Registration urls
 
 If you do not wish to configure all of your own URLs for the various registration views, there are several default definitions that you can include in your `urls.py` file.
 
+There is an URL file for :ref:`each of the default backends <basic-urls>`. These files provide all the URLs that you will need for normal interaction.
+
+If you wish to include just the authentication URLs, either because you want to expose them under a different path, or because you want to manually configure the URLs for the other views, there is a separate :ref:`include for that <authentication-urls>`.
+
+.. _basic-urls:
+
 Basic URLs
 ~~~~~~~~~~
 
@@ -15,28 +21,28 @@ These URLs are provided by any of the following:
  * ``registration.backends.simple.urls``
 
 **login/**
- * View: `django.contrib.auth.views.LoginView`
+ * View: ``django.contrib.auth.views.LoginView``
 
 **logout/**
- * View: `django.contrib.auth.views.LogoutView`
+ * View: ``django.contrib.auth.views.LogoutView``
 
 **password/change/**
- * View: `django.contrib.auth.views.PasswordChangeDoneView`
+ * View: ``django.contrib.auth.views.PasswordChangeDoneView``
 
 **password/change/done/**
- * View: `django.contrib.auth.views.PasswordResetView`
+ * View: ``django.contrib.auth.views.PasswordResetView``
 
 **password/reset/**
- * View: `django.contrib.auth.views.PasswordResetView`
+ * View: ``django.contrib.auth.views.PasswordResetView``
 
 **password/reset/complete/**
- * View: `django.contrib.auth.views.PasswordResetCompleteView`
+ * View: ``django.contrib.auth.views.PasswordResetCompleteView``
 
 **password/reset/done/**
- * View: `django.contrib.auth.views.PasswordResetDoneView`
+ * View: ``django.contrib.auth.views.PasswordResetDoneView``
 
 **password/reset/confirm/{token}/**
- * View: `django.contrib.auth.views.PasswordResetConfirmView`
+ * View: ``django.contrib.auth.views.PasswordResetConfirmView``
 
 **register/**
  * View: :py:class:`registration.views.RegistrationView`
@@ -45,7 +51,9 @@ These URLs are provided by any of the following:
 **register/closed/**
  * Template: :ref:`registration_closed.html <registration/registration_closed.html>`
 
-Authentication views
+.. _authentication-urls:
+
+Authentication URLs
 ~~~~~~~~~~~~~~~~~~~~
 
 Provided by ``registration.auth_urls``, or any of the above includes.
@@ -67,9 +75,9 @@ Provided by ``registration.auth_urls``, or any of the above includes.
 Admin approval backend
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Provided by `registration.backends.admin_approval.urls`
+This URL is only provided by ``registration.backends.admin_approval.urls``.
 
 **approve/{profile}/**
  * View: :py:class:`registration.backends.admin_approval.views.ApprovalView`
- * Template: `registration/admin_approve.html`
+ * Template: ``registration/admin_approve.html``
 

--- a/docs/urls.rst
+++ b/docs/urls.rst
@@ -43,7 +43,7 @@ These URLs are provided by any of the following:
  * Template: :ref:`registration_form.html <registration/registration_form.html>`
 
 **register/closed/**
- * Template: `registration/registration_closed.html`
+ * Template: :ref:`registration_closed.html <registration/registration_closed.html>`
 
 Authentication views
 ~~~~~~~~~~~~~~~~~~~~
@@ -55,7 +55,7 @@ Provided by ``registration.auth_urls``, or any of the above includes.
 
 **activate/resend/**
  * View: :py:class:`registration.views.ResendActivationView`
- * Template: `registration/resend_activation_complete.html`
+ * Template: :ref:`resend_activation_complete.html <registration/resend_activation_complete.html>`
 
 **activate/{key}/**
  * View: :py:class:`registration.views.ActivationView`
@@ -63,9 +63,6 @@ Provided by ``registration.auth_urls``, or any of the above includes.
 
 **register/complete/**
  * Template: :ref:`registration_complete.html <registration/registration_complete.html>`
-
-**register/closed/**
- * Template: `registration/registration_closed.html`
 
 Admin approval backend
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/urls.rst
+++ b/docs/urls.rst
@@ -1,0 +1,78 @@
+.. _urls:
+.. module:: registration.urls
+
+Registration urls
+==================
+
+If you do not wish to configure all of your own URLs for the various registration views, there are several default definitions that you can include in your `urls.py` file.
+
+Basic URLs
+~~~~~~~~~~
+
+These URLs are provided by any of the following:
+ * ``registration.backends.default.urls``
+ * ``registration.backends.admin_approval.urls``
+ * ``registration.backends.simple.urls``
+
+**login/**
+ * View: `django.contrib.auth.views.LoginView`
+
+**logout/**
+ * View: `django.contrib.auth.views.LogoutView`
+
+**password/change/**
+ * View: `django.contrib.auth.views.PasswordChangeDoneView`
+
+**password/change/done/**
+ * View: `django.contrib.auth.views.PasswordResetView`
+
+**password/reset/**
+ * View: `django.contrib.auth.views.PasswordResetView`
+
+**password/reset/complete/**
+ * View: `django.contrib.auth.views.PasswordResetCompleteView`
+
+**password/reset/done/**
+ * View: `django.contrib.auth.views.PasswordResetDoneView`
+
+**password/reset/confirm/{token}/**
+ * View: `django.contrib.auth.views.PasswordResetConfirmView`
+
+**register/**
+ * View: :py:class:`registration.views.RegistrationView`
+ * Template: :ref:`registration_form.html <registration/registration_form.html>`
+
+**register/closed/**
+ * Template: `registration/registration_closed.html`
+
+Authentication views
+~~~~~~~~~~~~~~~~~~~~
+
+Provided by ``registration.auth_urls``, or any of the above includes.
+
+**activate/complete/**
+ * Template: :ref:`activation_complete.html <registration/activation_complete.html>`
+
+**activate/resend/**
+ * View: :py:class:`registration.views.ResendActivationView`
+ * Template: `registration/resend_activation_complete.html`
+
+**activate/{key}/**
+ * View: :py:class:`registration.views.ActivationView`
+ * Template: :ref:`activate.html <registration/activate.html>`
+
+**register/complete/**
+ * Template: :ref:`registration_complete.html <registration/registration_complete.html>`
+
+**register/closed/**
+ * Template: `registration/registration_closed.html`
+
+Admin approval backend
+~~~~~~~~~~~~~~~~~~~~~~
+
+Provided by `registration.backends.admin_approval.urls`
+
+**approve/{profile}/**
+ * View: :py:class:`registration.backends.admin_approval.views.ApprovalView`
+ * Template: `registration/admin_approve.html`
+


### PR DESCRIPTION
This patch adds a new page to the documentation highlighting the actual URLs provided by the various `urls.py` files. It also adds documentation for a couple of templates not already present in the documentation.

This patch converts the heading for each template from a bold line to a reStructuredText subsubheading. This makes creating deep links cleaner. If you don't like this change, look at commit `b664aea`.

While most URLs have an associated view and template, some only have one. I've just omitted those sections, but we could explicitly call out those absences.

I'm open to ideas for what to do with the various URLs that reference Django builtin views. We could try to directly hotlink to the Django documentation. These views also come with templates, which I haven't bothered to document here, either.

Finally, there's the extra view and template provided by the `admin_approval` backend. There's no official documentation to hyperlink here. You might be fine with that, or we might want to create new entries for them.
