### PR TITLE
 Allow migrations to be ran backwards

### DIFF
--- a/registration/migrations/0003_migrate_activatedstatus.py
+++ b/registration/migrations/0003_migrate_activatedstatus.py
@@ -23,6 +23,4 @@ class Migration(migrations.Migration):
         ('registration', '0002_registrationprofile_activated'),
     ]
 
-    operations = [
-        migrations.RunPython(migrate_activated_status)
-    ]
+    operations = [migrations.RunPython(migrate_activated_status, migrations.RunPython.noop)]


### PR DESCRIPTION
currently django would raise exception if we tried to reverse the migrations because the data migration has no backwards. This avoids that problem [read more](https://django.doctor/advice/C8001)

I found this problem during auditing your codebase. [Read the full report](https://django.doctor/macropin/django-registration)