### PR TITLE
registration complete: show user e-mail he register with

### DIFF
--- a/registration/templates/registration/registration_complete.html
+++ b/registration/templates/registration/registration_complete.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Activation email sent" %}{% endblock %}
 
 {% block content %}
-<p>{% trans "Please check your email {{ request.session.registration_email }} to complete the registration process." %}</p>
+<p>{% trans "Please check your email, {{ request.session.registration_email }}, to complete the registration process." %}</p>
 {% endblock %}
 
 

--- a/registration/templates/registration/registration_complete.html
+++ b/registration/templates/registration/registration_complete.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Activation email sent" %}{% endblock %}
 
 {% block content %}
-<p>{% trans "Please check your email to complete the registration process." %}</p>
+<p>{% trans "Please check your email {{ request.session.registration_email }} to complete the registration process." %}</p>
 {% endblock %}
 
 

--- a/registration/tests/default_backend.py
+++ b/registration/tests/default_backend.py
@@ -2,6 +2,7 @@ import datetime
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
+from django.contrib.sessions.middleware import SessionMiddleware
 from django.core import mail
 from django.db import DatabaseError
 from django.test import TransactionTestCase
@@ -114,12 +115,15 @@ class DefaultBackendViewTests(TransactionTestCase):
             'password1': 'secret',
             'password2': 'secret'})
         request.user = AnonymousUser()
+        middleware = SessionMiddleware()
+        middleware.process_request(request)
         view(request)
 
         UserModel().objects.get(username='bob')
         # A registration profile was created, and no activation email was sent.
         self.assertEqual(self.registration_profile.objects.count(), 1)
         self.assertEqual(len(mail.outbox), 0)
+        self.assertEqual(request.session.get('registration_email'), "bob@example.com")
 
     @override_settings(
         INSTALLED_APPS=('django.contrib.auth', 'registration',)

--- a/registration/views.py
+++ b/registration/views.py
@@ -56,6 +56,9 @@ class RegistrationView(FormView):
         new_user = self.register(form)
         success_url = self.get_success_url(new_user)
 
+        if hasattr(self.request, "session"):
+            self.request.session['registration_email'] = form.cleaned_data['email']
+
         # success_url may be a simple string, or a tuple providing the
         # full argument set for redirect(). Attempting to unpack it
         # tells us which one it is.


### PR DESCRIPTION
Show user the e-mail he registered with on the Registration complete page. This can help user to see which e-mail box to check or if he made a mistake in the address.