### PR TITLE
Use blocktrans where we need to substitute a value

### DIFF
--- a/registration/templates/registration/registration_complete.html
+++ b/registration/templates/registration/registration_complete.html
@@ -4,7 +4,11 @@
 {% block title %}{% trans "Activation email sent" %}{% endblock %}
 
 {% block content %}
-<p>{% trans "Please check your email, {{ request.session.registration_email }}, to complete the registration process." %}</p>
+<p>
+  {% blocktrans with email=request.session.registration_email %}
+    Please check your email, {{ email }}, to complete the registration process.
+  {% endblocktrans %}
+</p>
 {% endblock %}
 
 


### PR DESCRIPTION
The change in #427 never actually worked, because you can't substitute variables inside `{% trans %}`. In fact, for a non-trivial variable like this, one has to use `{% blocktrans with foo=bar %}` to make a simple variable name available inside the translation string.