### PR TITLE
Fix verbose name

### DIFF
--- a/registration/apps.py
+++ b/registration/apps.py
@@ -3,5 +3,5 @@ from django.apps import AppConfig
 
 class RegistrationConfig(AppConfig):
     name = 'registration'
-    verbose_name = "Django-registration provides user registration functionality for Django websites."
+    verbose_name = "Registration"
     default_auto_field = 'django.db.models.AutoField'


### PR DESCRIPTION
This seems to have been introduced in #431. The `verbose_name` is used in the admin site to generate the title for the app. The current name seems inappropriate for this purpose.
![image](https://github.com/macropin/django-registration/assets/29607503/ae48f54b-c2dd-4ab6-a254-1a5ca37f25e0)

This PR changes the name back to the original name before #431.
![image](https://github.com/macropin/django-registration/assets/29607503/ba25cf38-bf35-4f4c-9cee-0c0a7443c284)
