### PR TITLE
Skip deleting users with protected/restricted relations

### DIFF
--- a/registration/models.py
+++ b/registration/models.py
@@ -281,7 +281,10 @@ class RegistrationManager(models.Manager):
                     user = profile.user
                     logger.warning('Deleting expired Registration profile {} and user {}.'.format(profile, user))
                     profile.delete()
-                    user.delete()
+                    try:
+                        user.delete()
+                    except (models.ProtectedError, models.RestrictedError) as e:
+                        logger.error('Deletion of user {} is prevented: {}'.format(user, e))
                     deleted_count += 1
             except UserModel().DoesNotExist:
                 logger.warning('Deleting expired Registration profile {}'.format(profile))


### PR DESCRIPTION
Allow the registration profile cleanup to succeed when a user has protected or restricted relations. The cleanup assumes the users that are selected for cleanup have never been activated. But it is possible for an admin to activate a user without using the registration profile. When the user is then deactivated and the profile becomes a valid candidate for cleanup it may have associated records which prevent it from being deleted.