### PR TITLE
Test against Django 5.0, drop support Django <4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+venv/
 bin/
 build/
 develop-eggs/

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -3,5 +3,5 @@
 Release notes
 =============
 
-The |version| release of |project| supports Python 3.7, 3.8, 3.9, 3.10 and
-Django 3.1, 3.2, 4.0, and 4.1.
+The |version| release of |project| supports Python 3.8, 3.9, 3.10, 3.11, 3.12
+and Django 4.2 and 5.0

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ from registration import get_version
 
 
 class PyTest(TestCommand):
-
     def finalize_options(self):
         TestCommand.finalize_options(self)
         self.test_args = []
@@ -17,43 +16,41 @@ class PyTest(TestCommand):
     def run_tests(self):
         # import here, cause outside the eggs aren't loaded
         import pytest
+
         errno = pytest.main(self.test_args)
         sys.exit(errno)
 
 
 setup(
-    name='django-registration-redux',
-    version=get_version().replace(' ', '-'),
-    description='An extensible user-registration application for Django',
-    long_description=open('README.rst').read(),
-    author='Andrew Cutler',
-    author_email='macropin@gmail.com',
-    url='https://github.com/macropin/django-registration',
-    package_dir={'registration': 'registration'},
-    packages=find_packages(exclude='test_app'),
-    tests_require=['pytest-django'],
-    cmdclass={'test': PyTest},
+    name="django-registration-redux",
+    version=get_version().replace(" ", "-"),
+    description="An extensible user-registration application for Django",
+    long_description=open("README.rst").read(),
+    author="Andrew Cutler",
+    author_email="macropin@gmail.com",
+    url="https://github.com/macropin/django-registration",
+    package_dir={"registration": "registration"},
+    packages=find_packages(exclude="test_app"),
+    tests_require=["pytest-django"],
+    cmdclass={"test": PyTest},
     include_package_data=True,
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Environment :: Web Environment',
-        'Framework :: Django',
-        'Framework :: Django :: 3.1',
-        'Framework :: Django :: 3.2',
-        'Framework :: Django :: 4.0',
-        'Framework :: Django :: 4.1',
-        'Framework :: Django :: 4.2',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11',
-        'Topic :: Software Development :: Libraries :: Python Modules',
-        'Topic :: Utilities'
+        "Development Status :: 5 - Production/Stable",
+        "Environment :: Web Environment",
+        "Framework :: Django",
+        "Framework :: Django :: 4.2",
+        "Framework :: Django :: 5.0",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: BSD License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "Topic :: Utilities",
     ],
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,7 @@
 flake8
 coveralls
 isort==4.3.21
+setuptools
 tox
 invoke
 docutils

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,8 @@
 
 [tox]
 envlist =
-    py3{7,8,9}-django31,
-    py3{7,8,9}-django32,
-    py3{8,9,10}-django40,
-    py3{8,9,10,11}-django41,
     py3{8,9,10,11}-django42,
+    py3{10,11,12}-django50,
 skip_missing_interpreters=True
 
 [testenv]
@@ -17,8 +14,5 @@ commands =
   coverage run --source=registration setup.py test
 deps =
   -rtest-requirements.txt
-  django31: Django>=3.1,<3.2
-  django32: Django>=3.2,<3.3
-  django40: Django>=4.0,<4.1
-  django41: Django>=4.1,<4.2
   django42: Django>=4.2,<4.3
+  django50: Django>=5.0,<5.1


### PR DESCRIPTION
Following the suggestion for third party libraries, support pre-Django4.2 is dropped. https://docs.djangoproject.com/en/5.0/releases/5.0/#third-party-library-support-for-older-version-of-django