### PR TITLE
Fix: Variable syntax in Polish translation

### DIFF
--- a/registration/locale/pl/LC_MESSAGES/django.po
+++ b/registration/locale/pl/LC_MESSAGES/django.po
@@ -172,7 +172,7 @@ msgid ""
 msgstr ""
 "\n"
 "Z pozdrowieniami,\n"
-"% Zarząd (site_name)s \n"
+"Zarząd %(site_name)s \n"
 
 #: templates/registration/activation_email_subject.txt:1
 #: templates/registration/admin_approve_complete_email_subject.txt:1


### PR DESCRIPTION
This corrects an issue with variable syntax in a Polish translation.

fixes #450